### PR TITLE
docs(site): add marketing website with GitHub Pages deploy

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,45 @@
+name: Deploy marketing site to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "site/**"
+      - ".github/workflows/deploy-pages.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload site artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/site/assets/favicon.svg
+++ b/site/assets/favicon.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#7cf2d4"/>
+      <stop offset="100%" stop-color="#8aa6ff"/>
+    </linearGradient>
+  </defs>
+  <rect width="32" height="32" rx="6" fill="#0a0c12"/>
+  <path d="M16 4 L27 9.5 L27 22.5 L16 28 L5 22.5 L5 9.5 Z"
+        fill="none" stroke="url(#g)" stroke-width="1.6" stroke-linejoin="round"/>
+  <circle cx="16" cy="16" r="2.6" fill="url(#g)"/>
+  <path d="M16 13.4 L16 7 M16 18.6 L16 25 M18.6 16 L25 16 M13.4 16 L7 16"
+        stroke="url(#g)" stroke-width="1.2" stroke-linecap="round" opacity=".75"/>
+</svg>

--- a/site/index.html
+++ b/site/index.html
@@ -1,0 +1,565 @@
+<!doctype html>
+<html lang="en" data-theme="dark">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+    <meta name="color-scheme" content="dark light" />
+    <meta name="theme-color" content="#0a0a0f" media="(prefers-color-scheme: dark)" />
+    <meta name="theme-color" content="#fafafa" media="(prefers-color-scheme: light)" />
+
+    <title>memento-mcp · persistent memory for AI coding agents</title>
+    <meta
+      name="description"
+      content="A local-first MCP server that gives Claude Code, Codex, Cursor and any stdio-MCP client durable project memory: decisions, patterns, pitfalls, architecture notes and team-shared knowledge."
+    />
+
+    <meta property="og:title" content="memento-mcp" />
+    <meta
+      property="og:description"
+      content="Persistent memory for AI coding agents. Local-first, typed, token-aware."
+    />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+
+    <link rel="icon" href="assets/favicon.svg" type="image/svg+xml" />
+    <link
+      rel="preconnect"
+      href="https://fonts.googleapis.com"
+      crossorigin
+    />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+
+    <script>
+      // Theme bootstrap before paint to avoid flash.
+      (function () {
+        try {
+          var saved = localStorage.getItem('memento-theme');
+          var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+          var theme = saved || (prefersDark ? 'dark' : 'light');
+          document.documentElement.setAttribute('data-theme', theme);
+        } catch (e) {}
+      })();
+    </script>
+  </head>
+  <body>
+    <div class="bg-grid" aria-hidden="true"></div>
+    <div class="bg-glow" aria-hidden="true"></div>
+
+    <header class="nav">
+      <a class="brand" href="#top" aria-label="memento-mcp home">
+        <span class="brand-mark" aria-hidden="true">
+          <svg viewBox="0 0 32 32" width="22" height="22">
+            <defs>
+              <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+                <stop offset="0%" stop-color="var(--accent)" />
+                <stop offset="100%" stop-color="var(--accent-2)" />
+              </linearGradient>
+            </defs>
+            <path
+              d="M16 2 L29 9 L29 23 L16 30 L3 23 L3 9 Z"
+              fill="none"
+              stroke="url(#g)"
+              stroke-width="1.6"
+              stroke-linejoin="round"
+            />
+            <circle cx="16" cy="16" r="3" fill="url(#g)" />
+            <path
+              d="M16 13 L16 6 M16 19 L16 26 M19 16 L26 16 M13 16 L6 16"
+              stroke="url(#g)"
+              stroke-width="1.2"
+              stroke-linecap="round"
+              opacity=".7"
+            />
+          </svg>
+        </span>
+        <span class="brand-name">memento<span class="dim">-mcp</span></span>
+      </a>
+
+      <nav class="nav-links" aria-label="Primary">
+        <a href="#features">Features</a>
+        <a href="#how">How it works</a>
+        <a href="#install">Install</a>
+        <a
+          href="https://github.com/lfrmonteiro99/memento-mcp"
+          target="_blank"
+          rel="noopener"
+          >GitHub</a
+        >
+      </nav>
+
+      <button
+        id="theme-toggle"
+        class="theme-toggle"
+        type="button"
+        aria-label="Toggle color theme"
+        aria-pressed="false"
+        title="Toggle theme"
+      >
+        <svg class="icon icon-sun" viewBox="0 0 24 24" width="18" height="18" aria-hidden="true">
+          <circle cx="12" cy="12" r="4" fill="currentColor" />
+          <g stroke="currentColor" stroke-width="1.6" stroke-linecap="round">
+            <path d="M12 2v3" />
+            <path d="M12 19v3" />
+            <path d="M2 12h3" />
+            <path d="M19 12h3" />
+            <path d="M4.2 4.2l2.1 2.1" />
+            <path d="M17.7 17.7l2.1 2.1" />
+            <path d="M4.2 19.8l2.1-2.1" />
+            <path d="M17.7 6.3l2.1-2.1" />
+          </g>
+        </svg>
+        <svg class="icon icon-moon" viewBox="0 0 24 24" width="18" height="18" aria-hidden="true">
+          <path
+            d="M20 14.5A8 8 0 0 1 9.5 4a8 8 0 1 0 10.5 10.5z"
+            fill="currentColor"
+          />
+        </svg>
+      </button>
+    </header>
+
+    <main id="top">
+      <section class="hero">
+        <div class="hero-eyebrow">
+          <span class="dot"></span>
+          <span>v2.1.2 · MCP server · local-first</span>
+        </div>
+        <h1 class="hero-title">
+          Persistent memory for
+          <span class="grad-text">AI coding agents</span>.
+        </h1>
+        <p class="hero-sub">
+          A local-first MCP server that gives Claude Code, Codex, Cursor and any
+          stdio-MCP client <em>durable</em> project memory — decisions,
+          patterns, pitfalls, architecture notes, and team-shared knowledge.
+        </p>
+
+        <div class="hero-cta">
+          <a class="btn btn-primary" href="#install">
+            <span>Install</span>
+            <svg viewBox="0 0 24 24" width="16" height="16" aria-hidden="true">
+              <path
+                d="M5 12h14M13 6l6 6-6 6"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+          </a>
+          <a
+            class="btn btn-ghost"
+            href="https://github.com/lfrmonteiro99/memento-mcp"
+            target="_blank"
+            rel="noopener"
+          >
+            <svg viewBox="0 0 24 24" width="16" height="16" aria-hidden="true">
+              <path
+                fill="currentColor"
+                d="M12 .5a12 12 0 0 0-3.79 23.39c.6.11.82-.26.82-.58v-2.05c-3.34.73-4.05-1.4-4.05-1.4-.55-1.39-1.34-1.76-1.34-1.76-1.09-.74.08-.73.08-.73 1.21.09 1.85 1.24 1.85 1.24 1.07 1.84 2.81 1.31 3.5 1 .11-.78.42-1.31.76-1.61-2.66-.3-5.46-1.33-5.46-5.93 0-1.31.47-2.38 1.24-3.22-.12-.3-.54-1.52.12-3.17 0 0 1.01-.32 3.3 1.23a11.5 11.5 0 0 1 6 0c2.29-1.55 3.3-1.23 3.3-1.23.66 1.65.24 2.87.12 3.17.77.84 1.24 1.91 1.24 3.22 0 4.61-2.81 5.62-5.49 5.92.43.37.81 1.1.81 2.22v3.29c0 .32.22.7.83.58A12 12 0 0 0 12 .5z"
+              />
+            </svg>
+            <span>View on GitHub</span>
+          </a>
+        </div>
+
+        <div class="terminal" aria-label="Install snippet">
+          <div class="terminal-bar">
+            <span class="t-dot"></span>
+            <span class="t-dot"></span>
+            <span class="t-dot"></span>
+            <span class="t-title">~ — bash</span>
+            <button
+              class="t-copy"
+              type="button"
+              data-copy="npm install -g @lfrmonteiro99/memento-memory-mcp&#10;memento-mcp install&#10;memento-mcp import claude-md&#10;memento-mcp ui"
+              aria-label="Copy install commands"
+            >
+              <span class="t-copy-label">copy</span>
+            </button>
+          </div>
+          <pre class="terminal-body"><code><span class="prompt">$</span> <span class="cmd">npm install -g</span> <span class="arg">@lfrmonteiro99/memento-memory-mcp</span>
+<span class="prompt">$</span> <span class="cmd">memento-mcp</span> install
+<span class="prompt">$</span> <span class="cmd">memento-mcp</span> import claude-md
+<span class="prompt">$</span> <span class="cmd">memento-mcp</span> ui  <span class="comment"># open the local inspector</span>
+<span class="cursor"></span></code></pre>
+        </div>
+
+        <ul class="hero-marks" aria-label="Compatible clients">
+          <li>
+            <svg viewBox="0 0 24 24" width="14" height="14" aria-hidden="true">
+              <path
+                fill="currentColor"
+                d="M9 16.2 4.8 12l-1.4 1.4L9 19l12-12-1.4-1.4z"
+              />
+            </svg>
+            Claude Code
+          </li>
+          <li>
+            <svg viewBox="0 0 24 24" width="14" height="14" aria-hidden="true">
+              <path
+                fill="currentColor"
+                d="M9 16.2 4.8 12l-1.4 1.4L9 19l12-12-1.4-1.4z"
+              />
+            </svg>
+            Codex
+          </li>
+          <li>
+            <svg viewBox="0 0 24 24" width="14" height="14" aria-hidden="true">
+              <path
+                fill="currentColor"
+                d="M9 16.2 4.8 12l-1.4 1.4L9 19l12-12-1.4-1.4z"
+              />
+            </svg>
+            Cursor
+          </li>
+          <li>
+            <svg viewBox="0 0 24 24" width="14" height="14" aria-hidden="true">
+              <path
+                fill="currentColor"
+                d="M9 16.2 4.8 12l-1.4 1.4L9 19l12-12-1.4-1.4z"
+              />
+            </svg>
+            Any stdio-MCP client
+          </li>
+        </ul>
+      </section>
+
+      <section class="problem">
+        <div class="section-tag">// the problem</div>
+        <h2>Agents are powerful. They are also <span class="grad-text">amnesiac</span>.</h2>
+        <div class="problem-grid">
+          <div class="card">
+            <div class="card-icon">
+              <svg viewBox="0 0 24 24" width="22" height="22"><path fill="currentColor" d="M12 2a10 10 0 1 0 10 10A10 10 0 0 0 12 2zm0 18a8 8 0 1 1 8-8 8 8 0 0 1-8 8zm-1-13h2v6h-2zm0 8h2v2h-2z"/></svg>
+            </div>
+            <h3>They forget why.</h3>
+            <p>The decision you defended in three meetings? Gone next session.</p>
+          </div>
+          <div class="card">
+            <div class="card-icon">
+              <svg viewBox="0 0 24 24" width="22" height="22"><path fill="currentColor" d="M3 17h18v2H3zm0-7h18v2H3zm0-7h18v2H3z"/></svg>
+            </div>
+            <h3>You repeat context.</h3>
+            <p>Every chat starts with the same paragraph of project lore.</p>
+          </div>
+          <div class="card">
+            <div class="card-icon">
+              <svg viewBox="0 0 24 24" width="22" height="22"><path fill="currentColor" d="M11 9h2v6h-2zm1-4a8 8 0 1 0 8 8 8 8 0 0 0-8-8zm0 14a6 6 0 1 1 6-6 6 6 0 0 1-6 6z"/></svg>
+            </div>
+            <h3>Tokens drain.</h3>
+            <p>Hand-pasted memory burns context windows you'd rather spend on code.</p>
+          </div>
+        </div>
+      </section>
+
+      <section id="features" class="features">
+        <div class="section-tag">// what it does</div>
+        <h2>A typed memory layer that <span class="grad-text">survives sessions</span>.</h2>
+        <p class="section-sub">
+          Six memory types, ranked and retrieved by intent. Your agent stops
+          guessing and starts remembering.
+        </p>
+
+        <div class="types">
+          <span class="type-pill" data-type="fact">fact</span>
+          <span class="type-pill" data-type="decision">decision</span>
+          <span class="type-pill" data-type="preference">preference</span>
+          <span class="type-pill" data-type="pattern">pattern</span>
+          <span class="type-pill" data-type="architecture">architecture</span>
+          <span class="type-pill" data-type="pitfall">pitfall</span>
+        </div>
+
+        <div class="feature-grid">
+          <article class="feature">
+            <div class="feature-num">01</div>
+            <h3>Local-first by default</h3>
+            <p>
+              SQLite + FTS5 search. No vector database required. No mandatory
+              cloud account. Your project history doesn't quietly leak to a
+              SaaS.
+            </p>
+          </article>
+
+          <article class="feature">
+            <div class="feature-num">02</div>
+            <h3>Team memory through git</h3>
+            <p>
+              Team-scoped memories serialize to <code>.memento/memories/</code>.
+              Review, diff, commit, share — like normal project files.
+            </p>
+          </article>
+
+          <article class="feature">
+            <div class="feature-num">03</div>
+            <h3>Token-aware injection</h3>
+            <p>
+              Adaptive ranking with utility feedback. The right context lands in
+              the prompt — not all of it, the right of it.
+            </p>
+          </article>
+
+          <article class="feature">
+            <div class="feature-num">04</div>
+            <h3>Optional embeddings</h3>
+            <p>
+              FTS5 and vector results merged through one ranker. Bring your own
+              key when you want semantic search. Skip it when you don't.
+            </p>
+          </article>
+
+          <article class="feature">
+            <div class="feature-num">05</div>
+            <h3>Privacy that holds</h3>
+            <p>
+              <code>&lt;private&gt;…&lt;/private&gt;</code> regions are excluded
+              from search, embeddings, sync and LLM calls. Secret scrubbing at
+              write time.
+            </p>
+          </article>
+
+          <article class="feature">
+            <div class="feature-num">06</div>
+            <h3>Per-project policy</h3>
+            <p>
+              <code>.memento/policy.toml</code> controls required tags, banned
+              patterns, retention, and vault promotion — checked into the repo,
+              not into one developer's machine.
+            </p>
+          </article>
+
+          <article class="feature">
+            <div class="feature-num">07</div>
+            <h3>Session summaries</h3>
+            <p>
+              Capture the end-of-session signal deterministically, or with
+              optional LLM-assisted summaries via Anthropic or OpenAI.
+            </p>
+          </article>
+
+          <article class="feature">
+            <div class="feature-num">08</div>
+            <h3>Local web inspector</h3>
+            <p>
+              <code>memento-mcp ui</code> opens a browser inspector for memories,
+              sessions, projects, sync drift, analytics and health.
+            </p>
+          </article>
+        </div>
+      </section>
+
+      <section id="how" class="how">
+        <div class="section-tag">// how it works</div>
+        <h2>Capture. Store. Rank. <span class="grad-text">Inject</span>.</h2>
+
+        <div class="flow">
+          <div class="flow-node">
+            <span class="flow-num">1</span>
+            <h4>Agent activity</h4>
+            <p>Decisions, pitfalls and patterns surface during a session.</p>
+          </div>
+          <div class="flow-arrow" aria-hidden="true">
+            <svg viewBox="0 0 60 14" width="60" height="14">
+              <path
+                d="M2 7h52M48 2l8 5-8 5"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="1.4"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+          </div>
+          <div class="flow-node">
+            <span class="flow-num">2</span>
+            <h4>Typed store</h4>
+            <p>Memories are written to local SQLite with type, scope and tags.</p>
+          </div>
+          <div class="flow-arrow" aria-hidden="true">
+            <svg viewBox="0 0 60 14" width="60" height="14">
+              <path
+                d="M2 7h52M48 2l8 5-8 5"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="1.4"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+          </div>
+          <div class="flow-node">
+            <span class="flow-num">3</span>
+            <h4>Ranked retrieval</h4>
+            <p>FTS5 + optional embeddings, scored by type, recency and utility.</p>
+          </div>
+          <div class="flow-arrow" aria-hidden="true">
+            <svg viewBox="0 0 60 14" width="60" height="14">
+              <path
+                d="M2 7h52M48 2l8 5-8 5"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="1.4"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+          </div>
+          <div class="flow-node">
+            <span class="flow-num">4</span>
+            <h4>Context injection</h4>
+            <p>The right slice lands in your agent's prompt at the right time.</p>
+          </div>
+        </div>
+
+        <div class="snippet">
+          <div class="snippet-tabs">
+            <span class="tab active">decision.json</span>
+            <span class="tab">pitfall.json</span>
+          </div>
+          <pre><code>{
+  <span class="k">"type"</span>: <span class="s">"decision"</span>,
+  <span class="k">"title"</span>: <span class="s">"Use repository classes for complex SQL"</span>,
+  <span class="k">"body"</span>: <span class="s">"Keeps business logic out of controllers; easier perf tuning."</span>,
+  <span class="k">"scope"</span>: <span class="s">"project"</span>,
+  <span class="k">"tags"</span>: [<span class="s">"architecture"</span>, <span class="s">"backend"</span>],
+  <span class="k">"created_at"</span>: <span class="s">"2026-04-25T12:04:11Z"</span>
+}</code></pre>
+        </div>
+      </section>
+
+      <section class="local">
+        <div class="section-tag">// local-first</div>
+        <h2>Your memory. Your machine. <span class="grad-text">Your repo</span>.</h2>
+        <ul class="checks">
+          <li><span class="chk"></span>Local SQLite. No required cloud.</li>
+          <li><span class="chk"></span>FTS5 search out of the box.</li>
+          <li><span class="chk"></span>Optional embeddings — opt-in, your key.</li>
+          <li><span class="chk"></span>Team sync via git, not a SaaS.</li>
+          <li><span class="chk"></span>Private regions excluded from sync, search and LLM calls.</li>
+          <li><span class="chk"></span>Secret scrubbing at write time.</li>
+        </ul>
+      </section>
+
+      <section id="install" class="install">
+        <div class="section-tag">// 60-second tour</div>
+        <h2>From npm to <span class="grad-text">remembering</span>, in four steps.</h2>
+
+        <ol class="steps">
+          <li>
+            <h4>Install</h4>
+            <pre class="codeblock"><code>npm install -g @lfrmonteiro99/memento-memory-mcp</code></pre>
+          </li>
+          <li>
+            <h4>Wire your MCP client</h4>
+            <pre class="codeblock"><code>memento-mcp install</code></pre>
+            <p class="step-note">
+              Configures Claude Code, Codex, Cursor, or any other stdio-MCP client.
+            </p>
+          </li>
+          <li>
+            <h4>Import existing project memory</h4>
+            <pre class="codeblock"><code>memento-mcp import claude-md --dry-run
+memento-mcp import claude-md --no-confirm</code></pre>
+          </li>
+          <li>
+            <h4>Inspect &amp; share</h4>
+            <pre class="codeblock"><code>memento-mcp ui              <span class="comment"># local browser inspector</span>
+memento-mcp sync init       <span class="comment"># share team memory via git</span>
+memento-mcp sync pull</code></pre>
+          </li>
+        </ol>
+
+        <div class="cta-row">
+          <a
+            class="btn btn-primary"
+            href="https://github.com/lfrmonteiro99/memento-mcp"
+            target="_blank"
+            rel="noopener"
+            >Get it on GitHub</a
+          >
+          <a
+            class="btn btn-ghost"
+            href="https://www.npmjs.com/package/@luispmonteiro/memento-memory-mcp"
+            target="_blank"
+            rel="noopener"
+            >View on npm</a
+          >
+        </div>
+      </section>
+
+      <section class="quote">
+        <blockquote>
+          <span class="q">"</span>
+          Stop pasting the same project explanation into every new chat like a
+          medieval scribe with npm installed.
+          <span class="q">"</span>
+        </blockquote>
+        <span class="quote-attr">— the README, unrepentantly</span>
+      </section>
+    </main>
+
+    <footer>
+      <div class="foot-grid">
+        <div>
+          <div class="brand brand-foot">
+            <span class="brand-mark" aria-hidden="true">
+              <svg viewBox="0 0 32 32" width="20" height="20">
+                <path
+                  d="M16 2 L29 9 L29 23 L16 30 L3 23 L3 9 Z"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="1.6"
+                  stroke-linejoin="round"
+                />
+                <circle cx="16" cy="16" r="2.4" fill="currentColor" />
+              </svg>
+            </span>
+            <span class="brand-name">memento<span class="dim">-mcp</span></span>
+          </div>
+          <p class="foot-note">
+            Persistent memory for AI coding agents. MIT licensed.
+          </p>
+        </div>
+        <div>
+          <h5>Docs</h5>
+          <ul>
+            <li><a href="https://github.com/lfrmonteiro99/memento-mcp/blob/main/docs/install.md">Install &amp; client setup</a></li>
+            <li><a href="https://github.com/lfrmonteiro99/memento-mcp/blob/main/docs/import.md">Importing CLAUDE.md</a></li>
+            <li><a href="https://github.com/lfrmonteiro99/memento-mcp/blob/main/docs/team-sync.md">Team sync</a></li>
+            <li><a href="https://github.com/lfrmonteiro99/memento-mcp/blob/main/docs/mcp-tools.md">MCP tools reference</a></li>
+          </ul>
+        </div>
+        <div>
+          <h5>Features</h5>
+          <ul>
+            <li><a href="https://github.com/lfrmonteiro99/memento-mcp/blob/main/docs/policy.md">Per-project policy</a></li>
+            <li><a href="https://github.com/lfrmonteiro99/memento-mcp/blob/main/docs/embeddings.md">Optional embeddings</a></li>
+            <li><a href="https://github.com/lfrmonteiro99/memento-mcp/blob/main/docs/privacy.md">Privacy</a></li>
+            <li><a href="https://github.com/lfrmonteiro99/memento-mcp/blob/main/docs/web-inspector.md">Web inspector</a></li>
+          </ul>
+        </div>
+        <div>
+          <h5>Project</h5>
+          <ul>
+            <li><a href="https://github.com/lfrmonteiro99/memento-mcp">GitHub</a></li>
+            <li><a href="https://www.npmjs.com/package/@luispmonteiro/memento-memory-mcp">npm</a></li>
+            <li><a href="https://github.com/lfrmonteiro99/memento-mcp/blob/main/LICENSE">License</a></li>
+          </ul>
+        </div>
+      </div>
+      <div class="foot-bar">
+        <span>© <span id="year"></span> Luis Monteiro</span>
+        <span class="foot-status">
+          <span class="dot dot-live"></span> built local-first
+        </span>
+      </div>
+    </footer>
+
+    <script src="script.js" defer></script>
+  </body>
+</html>

--- a/site/script.js
+++ b/site/script.js
@@ -1,0 +1,126 @@
+/* memento-mcp · marketing site interactions */
+
+(function () {
+  'use strict';
+
+  const root = document.documentElement;
+  const toggle = document.getElementById('theme-toggle');
+  const STORAGE_KEY = 'memento-theme';
+
+  function getTheme() {
+    return root.getAttribute('data-theme') || 'dark';
+  }
+
+  function setTheme(theme) {
+    root.setAttribute('data-theme', theme);
+    try {
+      localStorage.setItem(STORAGE_KEY, theme);
+    } catch (e) {}
+    if (toggle) {
+      toggle.setAttribute('aria-pressed', theme === 'light' ? 'true' : 'false');
+      toggle.setAttribute(
+        'aria-label',
+        theme === 'light' ? 'Switch to dark theme' : 'Switch to light theme'
+      );
+    }
+  }
+
+  // initial sync (bootstrap script already set data-theme)
+  setTheme(getTheme());
+
+  if (toggle) {
+    toggle.addEventListener('click', function () {
+      setTheme(getTheme() === 'dark' ? 'light' : 'dark');
+    });
+  }
+
+  // follow system preference until user picks
+  if (window.matchMedia) {
+    const mq = window.matchMedia('(prefers-color-scheme: dark)');
+    if (mq.addEventListener) {
+      mq.addEventListener('change', function (e) {
+        let saved = null;
+        try {
+          saved = localStorage.getItem(STORAGE_KEY);
+        } catch (err) {}
+        if (!saved) setTheme(e.matches ? 'dark' : 'light');
+      });
+    }
+  }
+
+  // sticky nav border on scroll
+  const nav = document.querySelector('.nav');
+  if (nav) {
+    const onScroll = function () {
+      if (window.scrollY > 8) nav.classList.add('scrolled');
+      else nav.classList.remove('scrolled');
+    };
+    onScroll();
+    window.addEventListener('scroll', onScroll, { passive: true });
+  }
+
+  // copy buttons
+  document.querySelectorAll('[data-copy]').forEach(function (btn) {
+    btn.addEventListener('click', async function () {
+      const text = btn.getAttribute('data-copy') || '';
+      const label = btn.querySelector('.t-copy-label');
+      const original = label ? label.textContent : null;
+      try {
+        await navigator.clipboard.writeText(text);
+      } catch (e) {
+        const ta = document.createElement('textarea');
+        ta.value = text;
+        ta.setAttribute('readonly', '');
+        ta.style.position = 'absolute';
+        ta.style.left = '-9999px';
+        document.body.appendChild(ta);
+        ta.select();
+        try {
+          document.execCommand('copy');
+        } catch (err) {}
+        document.body.removeChild(ta);
+      }
+      btn.classList.add('copied');
+      if (label) label.textContent = 'copied';
+      setTimeout(function () {
+        btn.classList.remove('copied');
+        if (label && original) label.textContent = original;
+      }, 1400);
+    });
+  });
+
+  // feature card spotlight follows cursor
+  document.querySelectorAll('.feature').forEach(function (el) {
+    el.addEventListener('mousemove', function (e) {
+      const rect = el.getBoundingClientRect();
+      const x = ((e.clientX - rect.left) / rect.width) * 100;
+      const y = ((e.clientY - rect.top) / rect.height) * 100;
+      el.style.setProperty('--mx', x + '%');
+      el.style.setProperty('--my', y + '%');
+    });
+  });
+
+  // reveal on intersect
+  if ('IntersectionObserver' in window) {
+    const targets = document.querySelectorAll(
+      '.card, .feature, .flow-node, .steps li, .checks li, .terminal, .snippet, .quote blockquote'
+    );
+    targets.forEach(function (t) { t.classList.add('reveal'); });
+    const io = new IntersectionObserver(
+      function (entries) {
+        entries.forEach(function (entry) {
+          if (entry.isIntersecting) {
+            entry.target.classList.add('in');
+            io.unobserve(entry.target);
+          }
+        });
+      },
+      { threshold: 0.12, rootMargin: '0px 0px -40px 0px' }
+    );
+    targets.forEach(function (t) { io.observe(t); });
+  }
+
+  // year stamp
+  const y = document.getElementById('year');
+  if (y) y.textContent = new Date().getFullYear();
+})();

--- a/site/styles.css
+++ b/site/styles.css
@@ -1,0 +1,1151 @@
+/* ============================================================
+   memento-mcp · marketing site
+   Tokens, theme switch, layout, components.
+   ============================================================ */
+
+:root {
+  --max: 1180px;
+  --radius: 14px;
+  --radius-lg: 22px;
+  --radius-sm: 8px;
+
+  --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI',
+    Roboto, Helvetica, Arial, sans-serif;
+  --font-mono: 'JetBrains Mono', 'SF Mono', ui-monospace, Menlo, Consolas,
+    monospace;
+
+  --ease: cubic-bezier(.2, .7, .2, 1);
+
+  --shadow-1: 0 1px 2px rgba(0, 0, 0, .04), 0 4px 16px rgba(0, 0, 0, .06);
+  --shadow-2: 0 1px 2px rgba(0, 0, 0, .06), 0 12px 40px rgba(0, 0, 0, .12);
+}
+
+/* dark (default) */
+:root,
+[data-theme='dark'] {
+  --bg: #07080c;
+  --bg-elev: #0c0e14;
+  --bg-elev-2: #11141c;
+  --surface: rgba(255, 255, 255, .03);
+  --surface-strong: rgba(255, 255, 255, .06);
+  --border: rgba(255, 255, 255, .08);
+  --border-strong: rgba(255, 255, 255, .14);
+
+  --fg: #e7e9ee;
+  --fg-soft: #b6bac6;
+  --fg-mute: #7a8092;
+  --fg-dim: #5a6072;
+
+  --accent: #7cf2d4;        /* mint */
+  --accent-2: #8aa6ff;      /* indigo */
+  --accent-3: #c084fc;      /* violet */
+  --accent-glow: rgba(124, 242, 212, .25);
+
+  --code-bg: #0a0c12;
+  --code-fg: #d6e1ec;
+  --code-key: #8aa6ff;
+  --code-str: #7cf2d4;
+  --code-cmt: #5a6072;
+
+  --grid-line: rgba(255, 255, 255, .045);
+  --glow-1: radial-gradient(60% 50% at 18% 12%, rgba(124, 242, 212, .14), transparent 60%),
+            radial-gradient(50% 60% at 85% 8%, rgba(138, 166, 255, .12), transparent 65%),
+            radial-gradient(50% 50% at 60% 100%, rgba(192, 132, 252, .10), transparent 60%);
+}
+
+/* light */
+[data-theme='light'] {
+  --bg: #fafafb;
+  --bg-elev: #ffffff;
+  --bg-elev-2: #ffffff;
+  --surface: rgba(10, 12, 18, .03);
+  --surface-strong: rgba(10, 12, 18, .055);
+  --border: rgba(10, 12, 18, .09);
+  --border-strong: rgba(10, 12, 18, .16);
+
+  --fg: #0d1018;
+  --fg-soft: #2c3140;
+  --fg-mute: #5e667a;
+  --fg-dim: #8a90a2;
+
+  --accent: #0a8c6a;
+  --accent-2: #3a5cff;
+  --accent-3: #7c3aed;
+  --accent-glow: rgba(58, 92, 255, .18);
+
+  --code-bg: #0b0d14;
+  --code-fg: #e6ecf5;
+  --code-key: #8aa6ff;
+  --code-str: #7cf2d4;
+  --code-cmt: #6f7689;
+
+  --grid-line: rgba(10, 12, 18, .055);
+  --glow-1: radial-gradient(60% 50% at 18% 12%, rgba(10, 140, 106, .10), transparent 60%),
+            radial-gradient(50% 60% at 85% 8%, rgba(58, 92, 255, .10), transparent 65%),
+            radial-gradient(50% 50% at 60% 100%, rgba(124, 58, 237, .07), transparent 60%);
+}
+
+/* ============================================================
+   reset & base
+   ============================================================ */
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  background: var(--bg);
+  color: var(--fg);
+  font-family: var(--font-sans);
+  font-size: 16px;
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+  min-height: 100vh;
+  position: relative;
+  overflow-x: hidden;
+  transition: background-color .35s var(--ease), color .35s var(--ease);
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+::selection {
+  background: var(--accent-glow);
+  color: var(--fg);
+}
+
+/* ============================================================
+   ambient background: dot grid + glow
+   ============================================================ */
+
+.bg-grid {
+  position: fixed;
+  inset: 0;
+  z-index: -2;
+  background-image:
+    linear-gradient(to right, var(--grid-line) 1px, transparent 1px),
+    linear-gradient(to bottom, var(--grid-line) 1px, transparent 1px);
+  background-size: 56px 56px;
+  mask-image: radial-gradient(ellipse at 50% 0%, #000 0%, #000 60%, transparent 100%);
+  -webkit-mask-image: radial-gradient(ellipse at 50% 0%, #000 0%, #000 60%, transparent 100%);
+  pointer-events: none;
+}
+
+.bg-glow {
+  position: fixed;
+  inset: 0;
+  z-index: -1;
+  background: var(--glow-1);
+  pointer-events: none;
+  transition: background .35s var(--ease);
+}
+
+/* ============================================================
+   layout
+   ============================================================ */
+
+.nav,
+main,
+footer {
+  max-width: var(--max);
+  margin: 0 auto;
+  padding-left: clamp(20px, 4vw, 36px);
+  padding-right: clamp(20px, 4vw, 36px);
+}
+
+main {
+  padding-top: 0;
+  padding-bottom: 80px;
+}
+
+section {
+  padding-block: clamp(64px, 10vw, 120px);
+  scroll-margin-top: 80px;
+}
+
+section + section {
+  border-top: 1px dashed var(--border);
+}
+
+h1,
+h2,
+h3,
+h4,
+h5 {
+  margin: 0;
+  letter-spacing: -.01em;
+  color: var(--fg);
+}
+
+p {
+  color: var(--fg-soft);
+}
+
+/* ============================================================
+   nav
+   ============================================================ */
+
+.nav {
+  display: flex;
+  align-items: center;
+  gap: 24px;
+  padding-top: 22px;
+  padding-bottom: 22px;
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  backdrop-filter: blur(10px) saturate(120%);
+  -webkit-backdrop-filter: blur(10px) saturate(120%);
+  background: color-mix(in oklab, var(--bg) 70%, transparent);
+  border-bottom: 1px solid transparent;
+  transition: border-color .25s var(--ease), background .25s var(--ease);
+}
+
+.nav.scrolled {
+  border-bottom-color: var(--border);
+}
+
+.brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  font-weight: 700;
+  letter-spacing: -.01em;
+  color: var(--fg);
+}
+
+.brand-mark {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  border-radius: 8px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+}
+
+.brand-name {
+  font-size: 15px;
+}
+
+.brand-name .dim {
+  color: var(--fg-mute);
+  font-weight: 500;
+}
+
+.nav-links {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin-left: auto;
+}
+
+.nav-links a {
+  padding: 8px 12px;
+  border-radius: 8px;
+  font-size: 14px;
+  color: var(--fg-soft);
+  transition: color .2s var(--ease), background .2s var(--ease);
+}
+
+.nav-links a:hover {
+  color: var(--fg);
+  background: var(--surface);
+}
+
+@media (max-width: 720px) {
+  .nav-links a {
+    display: none;
+  }
+  .nav-links a:last-child {
+    display: inline-flex;
+  }
+}
+
+/* theme toggle */
+.theme-toggle {
+  width: 36px;
+  height: 36px;
+  border-radius: 10px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  color: var(--fg-soft);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  transition: color .25s var(--ease), border-color .25s var(--ease),
+    background .25s var(--ease);
+}
+
+.theme-toggle:hover {
+  color: var(--fg);
+  border-color: var(--border-strong);
+}
+
+.theme-toggle .icon {
+  position: absolute;
+  transition: transform .35s var(--ease), opacity .25s var(--ease);
+}
+
+[data-theme='dark'] .icon-sun {
+  transform: scale(0.6) rotate(-90deg);
+  opacity: 0;
+}
+[data-theme='dark'] .icon-moon {
+  transform: scale(1) rotate(0);
+  opacity: 1;
+}
+[data-theme='light'] .icon-sun {
+  transform: scale(1) rotate(0);
+  opacity: 1;
+}
+[data-theme='light'] .icon-moon {
+  transform: scale(0.6) rotate(90deg);
+  opacity: 0;
+}
+
+/* ============================================================
+   hero
+   ============================================================ */
+
+.hero {
+  padding-top: clamp(48px, 9vw, 96px);
+  padding-bottom: clamp(48px, 9vw, 96px);
+  text-align: center;
+}
+
+.hero-eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--fg-mute);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 6px 12px;
+}
+
+.hero-eyebrow .dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--accent);
+  box-shadow: 0 0 0 3px color-mix(in oklab, var(--accent) 25%, transparent),
+    0 0 12px var(--accent);
+  animation: pulse 2.4s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: .55; }
+}
+
+.hero-title {
+  font-size: clamp(34px, 6.5vw, 68px);
+  line-height: 1.04;
+  font-weight: 800;
+  margin: 22px auto 18px;
+  max-width: 16ch;
+  letter-spacing: -.025em;
+}
+
+.grad-text {
+  background: linear-gradient(120deg, var(--accent), var(--accent-2) 55%, var(--accent-3));
+  background-clip: text;
+  -webkit-background-clip: text;
+  color: transparent;
+  -webkit-text-fill-color: transparent;
+}
+
+.hero-sub {
+  max-width: 60ch;
+  margin: 0 auto;
+  font-size: clamp(15px, 1.6vw, 18px);
+  color: var(--fg-soft);
+}
+
+.hero-sub em {
+  color: var(--fg);
+  font-style: normal;
+  background: linear-gradient(transparent 70%, var(--accent-glow) 70%);
+  padding: 0 2px;
+}
+
+.hero-cta {
+  margin-top: 28px;
+  display: flex;
+  gap: 10px;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 18px;
+  border-radius: 10px;
+  font-weight: 600;
+  font-size: 14px;
+  border: 1px solid transparent;
+  cursor: pointer;
+  transition: transform .15s var(--ease), background .2s var(--ease),
+    border-color .2s var(--ease), box-shadow .25s var(--ease);
+}
+
+.btn-primary {
+  background: linear-gradient(180deg, var(--fg) 0%, color-mix(in oklab, var(--fg) 92%, var(--accent)) 100%);
+  color: var(--bg);
+  box-shadow: 0 1px 0 rgba(255, 255, 255, .12) inset,
+    0 8px 24px -8px var(--accent-glow);
+}
+
+.btn-primary:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 1px 0 rgba(255, 255, 255, .12) inset,
+    0 14px 36px -10px var(--accent-glow);
+}
+
+.btn-ghost {
+  background: var(--surface);
+  border-color: var(--border);
+  color: var(--fg);
+}
+
+.btn-ghost:hover {
+  border-color: var(--border-strong);
+  background: var(--surface-strong);
+}
+
+/* terminal */
+.terminal {
+  margin: 44px auto 0;
+  max-width: 720px;
+  text-align: left;
+  border-radius: var(--radius-lg);
+  background: var(--code-bg);
+  border: 1px solid var(--border);
+  overflow: hidden;
+  box-shadow:
+    0 1px 0 rgba(255, 255, 255, .06) inset,
+    0 30px 80px -30px rgba(0, 0, 0, .55),
+    0 0 0 1px var(--border);
+  position: relative;
+}
+
+.terminal::before {
+  content: '';
+  position: absolute;
+  inset: -1px;
+  border-radius: inherit;
+  padding: 1px;
+  background: linear-gradient(135deg, var(--accent), transparent 35%, var(--accent-2) 80%);
+  -webkit-mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+  -webkit-mask-composite: xor;
+          mask-composite: exclude;
+  opacity: .35;
+  pointer-events: none;
+}
+
+.terminal-bar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 14px;
+  background: rgba(255, 255, 255, .03);
+  border-bottom: 1px solid rgba(255, 255, 255, .06);
+}
+
+.t-dot {
+  width: 11px;
+  height: 11px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, .15);
+}
+
+.t-dot:nth-child(1) { background: #ff5f57; }
+.t-dot:nth-child(2) { background: #febc2e; }
+.t-dot:nth-child(3) { background: #28c840; }
+
+.t-title {
+  margin-left: 10px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: rgba(214, 225, 236, .55);
+}
+
+.t-copy {
+  margin-left: auto;
+  background: transparent;
+  border: 1px solid rgba(255, 255, 255, .12);
+  color: rgba(214, 225, 236, .8);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  padding: 4px 8px;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: color .15s var(--ease), border-color .15s var(--ease),
+    background .15s var(--ease);
+}
+
+.t-copy:hover {
+  color: #fff;
+  border-color: rgba(255, 255, 255, .24);
+  background: rgba(255, 255, 255, .04);
+}
+
+.t-copy.copied {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+
+.terminal-body {
+  margin: 0;
+  padding: 18px 18px 22px;
+  font-family: var(--font-mono);
+  font-size: 13.5px;
+  line-height: 1.75;
+  color: var(--code-fg);
+  overflow-x: auto;
+  white-space: pre;
+}
+
+.terminal-body code {
+  font-family: inherit;
+}
+
+.prompt { color: var(--code-cmt); user-select: none; }
+.cmd { color: var(--code-key); }
+.arg { color: var(--code-str); }
+.comment { color: var(--code-cmt); }
+
+.cursor {
+  display: inline-block;
+  width: 8px;
+  height: 1.05em;
+  margin-left: 2px;
+  vertical-align: -2px;
+  background: var(--code-fg);
+  animation: blink 1.1s steps(2, end) infinite;
+}
+
+@keyframes blink {
+  50% { opacity: 0; }
+}
+
+.hero-marks {
+  list-style: none;
+  padding: 0;
+  margin: 28px 0 0;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 8px 18px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--fg-mute);
+}
+
+.hero-marks li {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.hero-marks svg {
+  color: var(--accent);
+}
+
+/* ============================================================
+   section: shared
+   ============================================================ */
+
+.section-tag {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--fg-mute);
+  letter-spacing: .04em;
+  margin-bottom: 14px;
+}
+
+section h2 {
+  font-size: clamp(26px, 4vw, 42px);
+  font-weight: 700;
+  letter-spacing: -.02em;
+  line-height: 1.12;
+  max-width: 22ch;
+  margin-bottom: 14px;
+}
+
+.section-sub {
+  max-width: 56ch;
+  color: var(--fg-soft);
+  margin: 0 0 28px;
+}
+
+/* ============================================================
+   problem
+   ============================================================ */
+
+.problem-grid {
+  margin-top: 32px;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 16px;
+}
+
+@media (max-width: 840px) {
+  .problem-grid { grid-template-columns: 1fr; }
+}
+
+.card {
+  padding: 24px;
+  border-radius: var(--radius);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  transition: transform .25s var(--ease), border-color .25s var(--ease),
+    background .25s var(--ease);
+}
+
+.card:hover {
+  border-color: var(--border-strong);
+  background: var(--surface-strong);
+  transform: translateY(-2px);
+}
+
+.card-icon {
+  width: 38px;
+  height: 38px;
+  border-radius: 10px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 12px;
+  background: linear-gradient(180deg, var(--surface-strong), var(--surface));
+  color: var(--accent);
+  border: 1px solid var(--border);
+}
+
+.card h3 {
+  font-size: 17px;
+  margin-bottom: 6px;
+}
+
+.card p {
+  margin: 0;
+  font-size: 14.5px;
+  color: var(--fg-mute);
+}
+
+/* ============================================================
+   features
+   ============================================================ */
+
+.types {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 22px 0 36px;
+}
+
+.type-pill {
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  font-family: var(--font-mono);
+  font-size: 12.5px;
+  color: var(--fg-soft);
+  position: relative;
+  transition: color .2s var(--ease), border-color .2s var(--ease),
+    background .2s var(--ease);
+}
+
+.type-pill::before {
+  content: '';
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--accent);
+  display: inline-block;
+  margin-right: 8px;
+  vertical-align: 1px;
+}
+
+.type-pill[data-type='decision']::before { background: var(--accent-2); }
+.type-pill[data-type='preference']::before { background: var(--accent-3); }
+.type-pill[data-type='pattern']::before { background: #f7c948; }
+.type-pill[data-type='architecture']::before { background: #ff8a65; }
+.type-pill[data-type='pitfall']::before { background: #ef4444; }
+
+.type-pill:hover {
+  color: var(--fg);
+  border-color: var(--border-strong);
+  background: var(--surface-strong);
+}
+
+.feature-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 14px;
+}
+
+@media (max-width: 1024px) {
+  .feature-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+}
+
+@media (max-width: 600px) {
+  .feature-grid { grid-template-columns: 1fr; }
+}
+
+.feature {
+  padding: 22px;
+  border-radius: var(--radius);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  position: relative;
+  overflow: hidden;
+  transition: transform .25s var(--ease), border-color .25s var(--ease);
+}
+
+.feature::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: radial-gradient(220px 120px at var(--mx, 50%) var(--my, 0%),
+    color-mix(in oklab, var(--accent) 30%, transparent), transparent 60%);
+  opacity: 0;
+  transition: opacity .35s var(--ease);
+  pointer-events: none;
+}
+
+.feature:hover {
+  transform: translateY(-2px);
+  border-color: var(--border-strong);
+}
+
+.feature:hover::after {
+  opacity: .6;
+}
+
+.feature-num {
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  color: var(--fg-dim);
+  margin-bottom: 12px;
+  letter-spacing: .04em;
+}
+
+.feature h3 {
+  font-size: 16px;
+  margin-bottom: 6px;
+}
+
+.feature p {
+  margin: 0;
+  font-size: 14px;
+  color: var(--fg-mute);
+}
+
+.feature code,
+section p code,
+.step-note code {
+  font-family: var(--font-mono);
+  font-size: .92em;
+  background: var(--surface-strong);
+  border: 1px solid var(--border);
+  color: var(--fg);
+  border-radius: 6px;
+  padding: 1px 6px;
+}
+
+/* ============================================================
+   how it works · flow
+   ============================================================ */
+
+.flow {
+  margin-top: 36px;
+  display: grid;
+  grid-template-columns:
+    minmax(0, 1fr) auto minmax(0, 1fr) auto minmax(0, 1fr) auto minmax(0, 1fr);
+  align-items: center;
+  gap: 12px;
+}
+
+@media (max-width: 900px) {
+  .flow {
+    grid-template-columns: 1fr;
+    gap: 8px;
+  }
+  .flow-arrow { transform: rotate(90deg); margin: 0 auto; }
+}
+
+.flow-node {
+  padding: 18px;
+  border-radius: var(--radius);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  position: relative;
+}
+
+.flow-node h4 {
+  font-size: 15px;
+  margin: 4px 0 4px;
+}
+
+.flow-node p {
+  margin: 0;
+  font-size: 13.5px;
+  color: var(--fg-mute);
+}
+
+.flow-num {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--accent);
+  letter-spacing: .08em;
+}
+
+.flow-arrow {
+  color: var(--fg-dim);
+  display: inline-flex;
+}
+
+.snippet {
+  margin-top: 36px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  background: var(--code-bg);
+}
+
+.snippet-tabs {
+  display: flex;
+  gap: 4px;
+  padding: 8px 8px 0;
+  background: rgba(255, 255, 255, .02);
+  border-bottom: 1px solid rgba(255, 255, 255, .06);
+}
+
+.snippet-tabs .tab {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  padding: 6px 12px;
+  border-radius: 6px 6px 0 0;
+  color: rgba(214, 225, 236, .5);
+  border: 1px solid transparent;
+  border-bottom: none;
+}
+
+.snippet-tabs .tab.active {
+  background: var(--code-bg);
+  color: var(--code-fg);
+  border-color: rgba(255, 255, 255, .08);
+}
+
+.snippet pre {
+  margin: 0;
+  padding: 18px 20px;
+  font-family: var(--font-mono);
+  font-size: 13px;
+  color: var(--code-fg);
+  overflow-x: auto;
+}
+
+.snippet .k { color: var(--code-key); }
+.snippet .s { color: var(--code-str); }
+
+/* ============================================================
+   local-first
+   ============================================================ */
+
+.checks {
+  list-style: none;
+  padding: 0;
+  margin: 32px 0 0;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px 24px;
+  max-width: 820px;
+}
+
+@media (max-width: 720px) {
+  .checks { grid-template-columns: 1fr; }
+}
+
+.checks li {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-size: 15px;
+  color: var(--fg-soft);
+}
+
+.chk {
+  width: 22px;
+  height: 22px;
+  border-radius: 6px;
+  background: linear-gradient(180deg, var(--accent), color-mix(in oklab, var(--accent) 70%, var(--accent-2)));
+  position: relative;
+  flex-shrink: 0;
+  box-shadow: 0 0 0 4px color-mix(in oklab, var(--accent) 18%, transparent);
+}
+
+.chk::after {
+  content: '';
+  position: absolute;
+  left: 6px;
+  top: 4px;
+  width: 6px;
+  height: 11px;
+  border-right: 2px solid var(--bg);
+  border-bottom: 2px solid var(--bg);
+  transform: rotate(45deg);
+}
+
+[data-theme='light'] .chk::after {
+  border-color: #fff;
+}
+
+/* ============================================================
+   install · steps
+   ============================================================ */
+
+.steps {
+  margin: 32px 0 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 16px;
+  counter-reset: step;
+}
+
+.steps li {
+  position: relative;
+  padding: 22px 22px 22px 64px;
+  border-radius: var(--radius);
+  border: 1px solid var(--border);
+  background: var(--surface);
+}
+
+.steps li::before {
+  counter-increment: step;
+  content: counter(step, decimal-leading-zero);
+  position: absolute;
+  left: 22px;
+  top: 22px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  letter-spacing: .04em;
+  color: var(--accent);
+  background: var(--surface-strong);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 4px 8px;
+}
+
+.steps h4 {
+  font-size: 16px;
+  margin: 0 0 10px;
+}
+
+.step-note {
+  margin: 8px 0 0;
+  font-size: 13.5px;
+  color: var(--fg-mute);
+}
+
+.codeblock {
+  margin: 0;
+  padding: 14px 16px;
+  background: var(--code-bg);
+  color: var(--code-fg);
+  border-radius: var(--radius-sm);
+  font-family: var(--font-mono);
+  font-size: 13.5px;
+  overflow-x: auto;
+  border: 1px solid rgba(255, 255, 255, .06);
+}
+
+[data-theme='light'] .codeblock {
+  border-color: rgba(255, 255, 255, .08);
+}
+
+.cta-row {
+  margin-top: 28px;
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+/* ============================================================
+   quote
+   ============================================================ */
+
+.quote {
+  text-align: center;
+  padding-block: clamp(56px, 8vw, 100px);
+}
+
+.quote blockquote {
+  margin: 0 auto;
+  max-width: 38ch;
+  font-size: clamp(20px, 2.6vw, 28px);
+  line-height: 1.35;
+  color: var(--fg);
+  font-weight: 500;
+  letter-spacing: -.01em;
+}
+
+.quote .q {
+  display: inline-block;
+  color: var(--accent);
+  font-family: var(--font-mono);
+  transform: translateY(2px);
+}
+
+.quote-attr {
+  display: block;
+  margin-top: 14px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--fg-mute);
+}
+
+/* ============================================================
+   footer
+   ============================================================ */
+
+footer {
+  border-top: 1px dashed var(--border);
+  padding-top: 56px;
+  padding-bottom: 40px;
+}
+
+.foot-grid {
+  display: grid;
+  grid-template-columns: 1.6fr repeat(3, 1fr);
+  gap: 32px 24px;
+  margin-bottom: 36px;
+}
+
+@media (max-width: 760px) {
+  .foot-grid {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+.foot-grid h5 {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--fg-mute);
+  letter-spacing: .04em;
+  margin-bottom: 12px;
+}
+
+.foot-grid ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 8px;
+}
+
+.foot-grid a {
+  color: var(--fg-soft);
+  font-size: 14px;
+  transition: color .2s var(--ease);
+}
+
+.foot-grid a:hover {
+  color: var(--fg);
+}
+
+.brand-foot {
+  margin-bottom: 10px;
+}
+
+.brand-foot .brand-mark {
+  color: var(--accent);
+  background: transparent;
+}
+
+.foot-note {
+  margin: 0;
+  font-size: 13.5px;
+  color: var(--fg-mute);
+  max-width: 32ch;
+}
+
+.foot-bar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--fg-mute);
+  border-top: 1px dashed var(--border);
+  padding-top: 18px;
+}
+
+.foot-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.dot-live {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--accent);
+  box-shadow: 0 0 10px var(--accent);
+  animation: pulse 2.4s ease-in-out infinite;
+}
+
+/* ============================================================
+   utility
+   ============================================================ */
+
+.reveal {
+  opacity: 0;
+  transform: translateY(14px);
+  transition: opacity .6s var(--ease), transform .6s var(--ease);
+}
+
+.reveal.in {
+  opacity: 1;
+  transform: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: .001ms !important;
+    transition-duration: .001ms !important;
+  }
+  html { scroll-behavior: auto; }
+}


### PR DESCRIPTION
Static, zero-build marketing site under /site with light/dark theme switch
(system-pref aware, persisted), dot-grid + glow background, glass cards,
mono terminal, copy-to-clipboard, cursor-spotlight on feature cards, and
intersection-reveal animations.

Adds .github/workflows/deploy-pages.yml that publishes /site to GitHub
Pages on push to main (paths-filtered) and on manual dispatch.

Site requires GitHub Pages source to be set to "GitHub Actions" in repo
settings.