### PR TITLE
docs: real hooks configs for Cursor, Codex, Gemini CLI, Cline

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,16 +301,19 @@ Read more: [Mode profiles](docs/mode-profiles.md)
 
 ### Automatic context injection and capture
 
-Memory tools (`memory_store`, `memory_search`, `decisions_log`, …) work in any stdio-MCP client. Automatic injection and capture use whatever extension mechanism the client provides.
+Memory tools (`memory_store`, `memory_search`, `decisions_log`, …) work in any stdio-MCP client. Automatic injection and capture use whatever extension mechanism the client provides — most major clients now expose lifecycle hooks.
 
-| Client | MCP tools | Auto-inject on prompt | Auto-capture after tools | End-of-session summary |
-| --- | :---: | :---: | :---: | :---: |
-| Claude Code | yes (native hooks) | yes (native hooks) | yes (native hooks) | yes (native hooks) |
-| Cursor | yes | via `.cursorrules` | n/a (no per-tool hook) | via rule + manual `/summarize` |
-| Codex | yes | via `AGENTS.md` | n/a (no per-tool hook) | via rule + manual `/summarize` |
-| Other stdio-MCP | yes | depends on client rules format | depends on client | depends on client |
+| Client | MCP tools | Hooks | Hooks since |
+| --- | :---: | :---: | :---: |
+| Claude Code | yes | yes (native) | shipped with Claude Code |
+| Cursor | yes | yes (native) | 1.7 (Oct 2025) |
+| Codex | yes | yes (native, opt-in flag) | 0.114.0 (Mar 2026) |
+| Gemini CLI | yes | yes (native) | 0.26.0 (Jan 2026) |
+| Cline | yes | yes (native) | 3.36.0 (late 2025) |
+| Aider | yes | no — rule-file fallback only | — |
+| Other stdio-MCP | yes | depends on client | — |
 
-Only Claude Code currently exposes deterministic lifecycle hooks. Other clients steer the agent through rule files (`.cursorrules`, `AGENTS.md`, system prompts), which is best-effort rather than guaranteed.
+Each client's hook event names and config format differ (e.g. Claude Code uses `UserPromptSubmit`, Cursor uses `beforeSubmitPrompt`, Cline filenames the events). The four `memento-hook-*` binaries were built for Claude Code's stdin payload shape; they work directly on Codex (very similar payload), and may need a light adapter on Cursor, Gemini CLI, and Cline. For clients without hooks, fall back to a rule file (`AGENTS.md`, `.cursor/rules/*.mdc`, system prompt) telling the agent to call the memory tools itself.
 
 Read more: [Installation & client setup](docs/install.md)
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -50,56 +50,15 @@ The installer detects which clients you have configured and writes the right con
 
 Restart the client after editing its config.
 
-### Codex
+### About hooks across clients
 
-Codex uses `~/.codex/config.toml`.
+The four `memento-hook-*` binaries (`memento-hook-session`, `memento-hook-search`, `memento-hook-capture`, `memento-hook-summarize`) were written for Claude Code's stdin payload shape. Practical compatibility with other clients today:
 
-Add:
+- **Claude Code** — first-class, fully tested.
+- **Codex 0.114.0+** — payload is very close (shared fields like `session_id`, `cwd`, `hook_event_name`); the binaries should work directly.
+- **Cursor 1.7+**, **Gemini CLI 0.26.0+**, **Cline 3.36.0+** — payload shapes differ; the binaries will receive JSON they don't fully understand. Inject pre-rendered context anyway, or write a small wrapper script that adapts the input. Treat the configs below as a starting point.
 
-```toml
-[mcp_servers.memento-mcp]
-command = "memento-mcp"
-args = []
-```
-
-If `memento-mcp` is not on `PATH`, use an absolute command instead:
-
-```toml
-[mcp_servers.memento-mcp]
-command = "/home/you/.nvm/versions/node/v20.20.2/bin/node"
-args = ["/home/you/.nvm/versions/node/v20.20.2/lib/node_modules/@lfrmonteiro99/memento-memory-mcp/dist/cli/main.js"]
-```
-
-#### Codex automation (no native hooks)
-
-Codex does not have lifecycle hooks. To approximate the Claude Code hooks behavior, add an `AGENTS.md` to the project root (Codex loads it automatically) telling the agent to call the memory tools itself:
-
-```markdown
-# Project memory (memento-mcp)
-
-This project uses memento-mcp. Follow these rules every session.
-
-## At the start of a session
-Call `memory_search` with the user's first non-trivial prompt and read the
-top 5 results. Also call `memory_search(query="pinned", detail="full")` to
-load pinned context. Treat returned `pitfall` and `decision` memories as
-binding constraints.
-
-## During the session
-- Before proposing a non-trivial change, call `memory_search` with keywords
-  from the task. Mention any matching `decision` or `pitfall` in your reply.
-- After learning something durable (a fix, a convention, a gotcha), call
-  `memory_store` with the right `memory_type` (`fact` / `decision` /
-  `pitfall` / `pattern` / `architecture` / `preference`) and a `scope` of
-  `project` (or `team` if it should sync via git).
-
-## At the end of a session
-When the user signals the session is wrapping up, call `memory_store` with
-`memory_type="session_summary"` and a concise digest of decisions made,
-pitfalls discovered, and follow-ups.
-```
-
-This is best-effort — the agent must choose to follow the rules, unlike Claude Code hooks which the harness enforces.
+For clients without hooks (Aider, older Codex/Cursor versions, niche clients), use the rule-file fallback shown at the end of this file.
 
 ### Claude Code
 
@@ -119,7 +78,7 @@ Add the MCP server:
 }
 ```
 
-Add hooks for context injection and auto-capture (Claude Code is currently the only client where these run automatically — see the per-client sections below for other clients):
+Add hooks for context injection and auto-capture:
 
 ```json
 {
@@ -150,9 +109,66 @@ What each hook does:
 - `PostToolUse` — captures meaningful tool output as memories with classifier dedup, cooldown, and secret scrubbing
 - `SessionEnd` — distills the session into a single `session_summary` memory (deterministic by default; opt-in LLM mode — see [Session summaries](session-summaries.md))
 
-### Cursor
+### Codex (0.114.0+)
 
-Cursor uses `~/.cursor/mcp.json`.
+Codex uses `~/.codex/config.toml` for the MCP server entry. Hooks are an opt-in feature flag.
+
+MCP server:
+
+```toml
+[mcp_servers.memento-mcp]
+command = "memento-mcp"
+args = []
+```
+
+If `memento-mcp` is not on `PATH`, use an absolute command instead:
+
+```toml
+[mcp_servers.memento-mcp]
+command = "/home/you/.nvm/versions/node/v20.20.2/bin/node"
+args = ["/home/you/.nvm/versions/node/v20.20.2/lib/node_modules/@lfrmonteiro99/memento-memory-mcp/dist/cli/main.js"]
+```
+
+Hooks (Codex 0.114.0, March 2026, or newer). First enable the experimental engine in `~/.codex/config.toml`:
+
+```toml
+[features]
+codex_hooks = true
+```
+
+Then add `~/.codex/hooks.json` (or `<repo>/.codex/hooks.json` for project-scoped):
+
+```json
+{
+  "hooks": {
+    "SessionStart": [
+      { "hooks": [{ "type": "command", "command": "memento-hook-session" }] }
+    ],
+    "UserPromptSubmit": [
+      { "hooks": [{ "type": "command", "command": "memento-hook-search" }] }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [{ "type": "command", "command": "memento-hook-capture", "timeout": 30 }]
+      }
+    ],
+    "Stop": [
+      { "hooks": [{ "type": "command", "command": "memento-hook-summarize", "timeout": 30 }] }
+    ]
+  }
+}
+```
+
+Codex calls `Stop` instead of `SessionEnd` and uses `Bash`-style matchers similar to Claude Code. Codex hook docs: <https://developers.openai.com/codex/hooks>.
+
+For Codex versions older than 0.114.0, use the rule-file fallback at the end.
+
+### Cursor (1.7+)
+
+Cursor uses `~/.cursor/mcp.json` for the MCP server and `.cursor/hooks.json` (or `~/.cursor/hooks.json`) for hooks.
+
+MCP server (`~/.cursor/mcp.json`):
 
 ```json
 {
@@ -165,32 +181,106 @@ Cursor uses `~/.cursor/mcp.json`.
 }
 ```
 
-#### Cursor automation (no native hooks)
+Hooks (Cursor 1.7, October 2025, or newer; still flagged beta in 2026). Project-scoped at `.cursor/hooks.json`:
 
-Cursor does not have lifecycle hooks either. Use a project rule file at `.cursor/rules/memento.mdc` (or `.cursorrules` for legacy setups):
-
-```markdown
----
-description: Use memento-mcp memory tools throughout the session
-alwaysApply: true
----
-
-This project uses memento-mcp for persistent memory.
-
-- At the start of every conversation, call `memory_search` with the user's
-  first task-shaped prompt and read the top results before answering.
-- Before proposing changes, call `memory_search` for relevant keywords and
-  honor any returned `decision` or `pitfall` memories.
-- When the user shares a durable fact, decision, convention, or gotcha,
-  call `memory_store` with the appropriate `memory_type` and `scope`
-  (`project` for repo-wide, `team` to sync via git, `global` for personal).
-- Before wrapping up, call `memory_store` with
-  `memory_type="session_summary"` summarizing what changed.
+```json
+{
+  "version": 1,
+  "hooks": {
+    "beforeSubmitPrompt": [
+      { "command": "memento-hook-search" }
+    ],
+    "afterFileEdit": [
+      { "command": "memento-hook-capture" }
+    ],
+    "stop": [
+      { "command": "memento-hook-summarize" }
+    ]
+  }
+}
 ```
 
-This is best-effort — the agent must follow the rule. Unlike Claude Code hooks, the client does not enforce it.
+Notes:
 
-### Generic MCP client
+- Cursor has no `SessionStart` event. The closest substitute is running `memento-hook-session` once on the first `beforeSubmitPrompt` (your wrapper script can short-circuit on subsequent calls), or invoke it manually with `memory_search(query="pinned")`.
+- Cursor's payload differs from Claude Code's — `memento-hook-capture` may need a small wrapper to translate `afterFileEdit` input (file path + diff) into something the binary expects. See <https://cursor.com/docs/hooks>.
+
+### Gemini CLI (0.26.0+)
+
+Gemini CLI uses `~/.gemini/settings.json` for both the MCP server and hooks. Hooks are default-enabled since 0.26.0 (28 January 2026).
+
+```json
+{
+  "mcpServers": {
+    "memento-mcp": {
+      "command": "memento-mcp",
+      "args": []
+    }
+  },
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          { "type": "command", "command": "memento-hook-session", "name": "MementoSessionStart", "timeout": 5000 }
+        ]
+      }
+    ],
+    "BeforeAgent": [
+      {
+        "hooks": [
+          { "type": "command", "command": "memento-hook-search", "name": "MementoSearch", "timeout": 5000 }
+        ]
+      }
+    ],
+    "AfterTool": [
+      {
+        "matcher": "run_shell_command|read_file|edit",
+        "hooks": [
+          { "type": "command", "command": "memento-hook-capture", "name": "MementoCapture", "timeout": 5000 }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          { "type": "command", "command": "memento-hook-summarize", "name": "MementoSummarize", "timeout": 10000 }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Notes:
+
+- Gemini CLI requires hook scripts to print only valid JSON to stdout (logs go to stderr). The current `memento-hook-*` binaries print injection text directly, so they will likely need a wrapper that re-emits the output inside `{"systemMessage": "..."}` until a Gemini-native mode lands.
+- Manage hooks at runtime with `/hooks` inside the CLI. Reference: <https://geminicli.com/docs/hooks/reference/>.
+
+### Cline (3.36.0+)
+
+Cline uses VS Code settings for the MCP server, and discovers hooks by **filename** in `.clinerules/hooks/` (project) or `~/Documents/Cline/Hooks/` (global).
+
+Register the MCP server through the Cline UI (`Settings → MCP Servers → Add`) with command `memento-mcp` and no args, or edit your VS Code `settings.json` accordingly.
+
+For hooks, create one executable file per event you want to wire up. On macOS/Linux they are extensionless executables; on Windows they must be `.ps1` scripts.
+
+```bash
+mkdir -p .clinerules/hooks
+cat > .clinerules/hooks/UserPromptSubmit <<'EOF'
+#!/bin/bash
+# Cline pipes JSON on stdin and expects JSON on stdout.
+INPUT=$(cat)
+INJECTED=$(echo "$INPUT" | memento-hook-search 2>/dev/null || true)
+jq -n --arg ctx "$INJECTED" '{cancel:false, contextModification:$ctx, errorMessage:""}'
+EOF
+chmod +x .clinerules/hooks/UserPromptSubmit
+```
+
+Wire similar files for `TaskStart` (→ `memento-hook-session`), `PostToolUse` (→ `memento-hook-capture`), and `TaskComplete` (→ `memento-hook-summarize`). The wrapper above is required because Cline's input/output schema (`taskId`, `workspaceRoots`, `cancel`, `contextModification`) does not match Claude Code's. Reference: <https://docs.cline.bot/customization/hooks>.
+
+Supported Cline events: `TaskStart`, `TaskResume`, `TaskCancel`, `TaskComplete`, `PreToolUse`, `PostToolUse`, `UserPromptSubmit`, `PreCompact` (since 3.36.0; expanded in 3.38.3).
+
+### Generic stdio-MCP client (and clients without hooks)
 
 If your client supports stdio MCP servers, use this shape:
 
@@ -204,18 +294,43 @@ If your client supports stdio MCP servers, use this shape:
 
 If PATH resolution is unreliable in your client, prefer the absolute `node` + `dist/cli/main.js` form shown above for Codex.
 
-#### Generic-client automation
+### Rule-file fallback (Aider, older versions, anything without hooks)
 
-If the client lacks lifecycle hooks, your only lever is a system-prompt or rule file telling the agent to call the memory tools at the right moments. The Codex `AGENTS.md` block above is a reasonable starting template — adapt the file path to whatever your client loads (`.aider.conf.yml` system prompt, Continue `config.json` `systemMessage`, etc.).
+When the client has no hook system (e.g. Aider, pre-1.7 Cursor, pre-0.114.0 Codex), the only lever is a rule file telling the agent to call the memory tools itself. This is best-effort — the agent must choose to follow the rules — but it is the most portable option.
 
-If the client *does* expose hooks or pre/post-message scripts, you can call the hook binaries directly:
+Drop one of these in your project:
 
-- `memento-hook-session` — equivalent of `SessionStart`
-- `memento-hook-search` — equivalent of `UserPromptSubmit`
-- `memento-hook-capture` — equivalent of `PostToolUse` (reads tool I/O on stdin)
-- `memento-hook-summarize` — equivalent of `SessionEnd`
+- Codex / generic agent harness → project root `AGENTS.md`
+- Cursor pre-1.7 → `.cursorrules` or `.cursor/rules/memento.mdc` (with `alwaysApply: true`)
+- Aider → system prompt via `--message-file` or `aider.conf.yml`
+- Continue, Roo, etc. → their respective rule/system-prompt mechanism
 
-All four read JSON on stdin in the Claude Code hook payload shape and write injection text to stdout. Adapter shims for other harnesses are welcome as PRs.
+Template:
+
+```markdown
+# Project memory (memento-mcp)
+
+This project uses memento-mcp. Follow these rules every session.
+
+## At the start of a session
+Call `memory_search` with the user's first non-trivial prompt and read the
+top 5 results. Also call `memory_search(query="pinned", detail="full")` to
+load pinned context. Treat returned `pitfall` and `decision` memories as
+binding constraints.
+
+## During the session
+- Before proposing a non-trivial change, call `memory_search` with keywords
+  from the task. Mention any matching `decision` or `pitfall` in your reply.
+- After learning something durable (a fix, a convention, a gotcha), call
+  `memory_store` with the right `memory_type` (`fact` / `decision` /
+  `pitfall` / `pattern` / `architecture` / `preference`) and a `scope` of
+  `project` (or `team` if it should sync via git).
+
+## At the end of a session
+When the user signals the session is wrapping up, call `memory_store` with
+`memory_type="session_summary"` and a concise digest of decisions made,
+pitfalls discovered, and follow-ups.
+```
 
 ## Verify installation
 


### PR DESCRIPTION
The previous docs claimed only Claude Code had lifecycle hooks. That is
no longer true: Cursor 1.7 (Oct 2025), Codex 0.114.0 (Mar 2026),
Gemini CLI 0.26.0 (Jan 2026), and Cline 3.36.0 (late 2025) all shipped
hook systems. The install guide pointed users at rule-file workarounds
when the real answer is now native hooks.

- README: replace the "Claude-only hooks" matrix with one that lists
  hook support and the version each client added it in.
- docs/install.md: add concrete hook configs for Codex (config.toml +
  hooks.json with codex_hooks feature flag), Cursor (.cursor/hooks.json
  v1 schema), Gemini CLI (settings.json with BeforeAgent / AfterTool /
  SessionStart / SessionEnd), and Cline (filesystem-discovered hooks
  in .clinerules/hooks/ with input/output JSON wrapper).
- Add an "About hooks across clients" preamble describing where the
  memento-hook-* binaries work directly (Claude Code, Codex) vs where
  a small payload-adapter wrapper is needed (Cursor, Gemini, Cline).
- Keep the rule-file template as an explicit fallback for Aider and any
  client without hooks (or on older versions of clients that have them).

https://claude.ai/code/session_012kYjq4xZykvxAY1hsszbfr