### PR TITLE
docs(site): surface token savings as the headline + add motion polish

### DIFF
--- a/site/src/components/Animations.astro
+++ b/site/src/components/Animations.astro
@@ -1,18 +1,29 @@
 ---
 ---
 
+<!-- ambient drifting orbs (replaces the static bg-glow scroll parallax) -->
+<div class="orbs" aria-hidden="true">
+  <span class="orb orb-1"></span>
+  <span class="orb orb-2"></span>
+  <span class="orb orb-3"></span>
+</div>
+
+<!-- nav scroll progress indicator -->
+<div class="scroll-progress" aria-hidden="true"><span></span></div>
+
 <script>
-  import { animate, inView, stagger } from 'motion';
+  import { animate, inView, stagger, scroll } from 'motion';
 
   const reduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 
-  // hero-level entrance
+  // -----------------------------------------------------------------
+  // generic fade-up reveal
+  // -----------------------------------------------------------------
   const heroItems = document.querySelectorAll<HTMLElement>('[data-anim="fade-up"]');
   if (!reduced && heroItems.length) {
     heroItems.forEach((el) => el.classList.add('will-reveal'));
 
-    // Hero items: animate immediately on load with their per-element delay.
-    const isHero = (el: HTMLElement) => !!el.closest('section.container-x.text-center');
+    const isHero = (el: HTMLElement) => !!el.closest('#hero');
     const heroSet: HTMLElement[] = [];
     heroItems.forEach((el) => { if (isHero(el)) heroSet.push(el); });
 
@@ -21,11 +32,10 @@
       animate(
         el,
         { opacity: [0, 1], transform: ['translateY(14px)', 'translateY(0px)'] },
-        { duration: 0.65, delay, easing: [0.2, 0.7, 0.2, 1] }
+        { duration: 0.65, delay, ease: [0.2, 0.7, 0.2, 1] }
       );
     });
 
-    // Non-hero: animate when entering viewport.
     const offscreen: HTMLElement[] = [];
     heroItems.forEach((el) => { if (!isHero(el)) offscreen.push(el); });
 
@@ -36,7 +46,7 @@
           animate(
             el,
             { opacity: [0, 1], transform: ['translateY(14px)', 'translateY(0px)'] },
-            { duration: 0.55, easing: [0.2, 0.7, 0.2, 1] }
+            { duration: 0.55, ease: [0.2, 0.7, 0.2, 1] }
           );
           return () => {};
         },
@@ -50,18 +60,54 @@
     });
   }
 
-  // terminal entrance with subtle scale
+  // -----------------------------------------------------------------
+  // terminal entrance + one-shot typing cascade
+  // -----------------------------------------------------------------
   const term = document.querySelector<HTMLElement>('[data-anim="terminal"]');
-  if (term && !reduced) {
-    term.classList.add('will-reveal');
-    animate(
-      term,
-      { opacity: [0, 1], transform: ['translateY(20px) scale(0.985)', 'translateY(0) scale(1)'] },
-      { duration: 0.85, delay: 0.25, easing: [0.2, 0.7, 0.2, 1] }
-    );
+  if (term) {
+    if (!reduced) {
+      term.classList.add('will-reveal');
+      animate(
+        term,
+        { opacity: [0, 1], transform: ['translateY(20px) scale(0.985)', 'translateY(0) scale(1)'] },
+        { duration: 0.85, delay: 0.25, ease: [0.2, 0.7, 0.2, 1] }
+      );
+
+      // Type-on cascade: split each line's spans into chars and fade them in.
+      const body = term.querySelector<HTMLElement>('.terminal-body code');
+      if (body) {
+        const spans = Array.from(body.querySelectorAll<HTMLElement>('span'));
+        // Skip the trailing blinking cursor span
+        const targets = spans.filter((s) => !s.classList.contains('cursor'));
+        // Hide originals, render character spans
+        targets.forEach((s) => {
+          if (s.dataset.typed === '1') return;
+          const text = s.textContent ?? '';
+          s.textContent = '';
+          for (const ch of text) {
+            const c = document.createElement('span');
+            c.textContent = ch;
+            c.style.opacity = '0';
+            s.appendChild(c);
+          }
+          s.dataset.typed = '1';
+        });
+
+        const allChars = targets.flatMap((s) => Array.from(s.querySelectorAll<HTMLElement>(':scope > span')));
+        if (allChars.length) {
+          animate(
+            allChars,
+            { opacity: [0, 1] },
+            { duration: 0.04, delay: stagger(0.012, { startDelay: 0.55 }), ease: 'linear' }
+          );
+        }
+      }
+    }
   }
 
+  // -----------------------------------------------------------------
   // type-pill stagger when section enters viewport
+  // -----------------------------------------------------------------
   const pills = document.querySelectorAll<HTMLElement>('.type-pill');
   if (pills.length && !reduced) {
     pills.forEach((p) => { p.style.opacity = '0'; p.style.transform = 'translateY(8px)'; });
@@ -73,7 +119,7 @@
           animate(
             pills,
             { opacity: [0, 1], transform: ['translateY(8px)', 'translateY(0px)'] },
-            { duration: 0.45, delay: stagger(0.06), easing: [0.2, 0.7, 0.2, 1] }
+            { duration: 0.45, delay: stagger(0.06), ease: [0.2, 0.7, 0.2, 1] }
           );
           return () => {};
         },
@@ -82,18 +128,35 @@
     }
   }
 
-  // parallax-ish glow on scroll
-  const glow = document.querySelector<HTMLElement>('.bg-glow');
-  if (glow && !reduced) {
-    let ticking = false;
-    window.addEventListener('scroll', () => {
-      if (ticking) return;
-      ticking = true;
-      requestAnimationFrame(() => {
-        const y = window.scrollY * 0.04;
-        glow.style.transform = `translateY(${y}px)`;
-        ticking = false;
-      });
-    }, { passive: true });
+  // -----------------------------------------------------------------
+  // ambient drifting orbs — long-loop spring-mirror motion
+  // -----------------------------------------------------------------
+  if (!reduced) {
+    const orbs = document.querySelectorAll<HTMLElement>('.orb');
+    const drifts = [
+      { x: 60, y: 40, dur: 22 },
+      { x: -50, y: 60, dur: 28 },
+      { x: 40, y: -50, dur: 34 },
+    ];
+    orbs.forEach((orb, i) => {
+      const d = drifts[i % drifts.length];
+      animate(
+        orb,
+        { x: [0, d.x, 0, -d.x, 0], y: [0, d.y, 0, -d.y, 0] },
+        { duration: d.dur, repeat: Infinity, ease: 'easeInOut' }
+      );
+    });
+  }
+
+  // -----------------------------------------------------------------
+  // nav scroll-progress bar (pure rAF via motion's scroll)
+  // -----------------------------------------------------------------
+  const progress = document.querySelector<HTMLElement>('.scroll-progress > span');
+  if (progress) {
+    progress.style.transformOrigin = 'left center';
+    progress.style.transform = 'scaleX(0)';
+    scroll((p: number) => {
+      progress.style.transform = `scaleX(${p})`;
+    });
   }
 </script>

--- a/site/src/components/Hero.astro
+++ b/site/src/components/Hero.astro
@@ -4,7 +4,7 @@ import Terminal from './Terminal.astro';
 const clients = ['Claude Code', 'Codex', 'Cursor', 'Any stdio-MCP client'];
 ---
 
-<section class="container-x py-[clamp(48px,9vw,96px)] text-center">
+<section id="hero" class="container-x py-[clamp(48px,9vw,96px)] text-center relative">
   <div class="inline-flex items-center gap-2 rounded-full border px-3 py-[6px] text-[12px]"
        data-anim="fade-up"
        style="font-family: var(--font-mono); color: var(--color-fg-mute); background: var(--color-surface); border-color: var(--color-border);">
@@ -22,8 +22,25 @@ const clients = ['Claude Code', 'Codex', 'Cursor', 'Any stdio-MCP client'];
     project memory — decisions, patterns, pitfalls, architecture notes, and team-shared knowledge.
   </p>
 
-  <div class="mt-7 flex flex-wrap justify-center gap-[10px]" data-anim="fade-up" data-anim-delay="180">
-    <a class="btn btn-primary" href="#install">
+  <a class="hero-savings-chip mx-auto mt-5 inline-flex items-center gap-[10px] rounded-full border px-[14px] py-[8px] text-[13px]"
+     href="#savings"
+     data-anim="fade-up"
+     data-anim-delay="160"
+     aria-label="See how Memento saves tokens">
+    <span class="hero-savings-spark" aria-hidden="true"></span>
+    <span style="font-family: var(--font-mono); color: var(--color-fg-mute);">saves</span>
+    <span class="grad-text font-bold tabular-nums" data-hero-count="2340">0</span>
+    <span class="font-semibold" style="color: var(--color-fg);">tokens / session</span>
+    <span style="color: var(--color-fg-mute);">·</span>
+    <span class="grad-text font-bold tabular-nums" data-hero-count="940000">0</span>
+    <span style="font-family: var(--font-mono); color: var(--color-fg-mute);">/mo for 5-dev teams</span>
+    <svg viewBox="0 0 24 24" width="14" height="14" aria-hidden="true" style="color: var(--color-fg-mute);">
+      <path d="M5 12h14M13 6l6 6-6 6" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+    </svg>
+  </a>
+
+  <div class="mt-7 flex flex-wrap justify-center gap-[10px]" data-anim="fade-up" data-anim-delay="200">
+    <a class="btn btn-primary" id="hero-cta-install" href="#install">
       <span>Install</span>
       <svg viewBox="0 0 24 24" width="16" height="16" aria-hidden="true">
         <path d="M5 12h14M13 6l6 6-6 6" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
@@ -52,3 +69,58 @@ const clients = ['Claude Code', 'Codex', 'Cursor', 'Any stdio-MCP client'];
     ))}
   </ul>
 </section>
+
+<script>
+  import { animate } from 'motion';
+
+  const reduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  const fmt = new Intl.NumberFormat();
+
+  // Hero savings chip count-up — fires on load (above the fold)
+  document.querySelectorAll<HTMLElement>('[data-hero-count]').forEach((el, i) => {
+    const to = Number(el.dataset.heroCount);
+    if (reduced) { el.textContent = fmt.format(to); return; }
+    el.textContent = '0';
+    const dur = to >= 100_000 ? 1.6 : 1.2;
+    animate(0, to, {
+      duration: dur,
+      delay: 0.45 + i * 0.15,
+      ease: [0.2, 0.7, 0.2, 1],
+      onUpdate: (v: number) => { el.textContent = fmt.format(Math.round(v)); },
+    });
+  });
+
+  // Magnetic primary CTA
+  const cta = document.getElementById('hero-cta-install');
+  if (cta && !reduced && window.matchMedia('(hover: hover)').matches) {
+    let raf = 0;
+    cta.addEventListener('pointermove', (e: PointerEvent) => {
+      const r = cta.getBoundingClientRect();
+      const dx = e.clientX - (r.left + r.width / 2);
+      const dy = e.clientY - (r.top + r.height / 2);
+      cancelAnimationFrame(raf);
+      raf = requestAnimationFrame(() => {
+        animate(
+          cta,
+          { x: dx * 0.18, y: dy * 0.28 },
+          { type: 'spring', stiffness: 280, damping: 22, mass: 0.6 }
+        );
+      });
+    });
+    cta.addEventListener('pointerleave', () => {
+      animate(cta, { x: 0, y: 0 }, { type: 'spring', stiffness: 200, damping: 20 });
+    });
+  }
+
+  // Cursor-tracking spotlight on hero
+  const hero = document.getElementById('hero');
+  if (hero && !reduced) {
+    hero.addEventListener('pointermove', (e: PointerEvent) => {
+      const r = hero.getBoundingClientRect();
+      const x = ((e.clientX - r.left) / r.width) * 100;
+      const y = ((e.clientY - r.top) / r.height) * 100;
+      hero.style.setProperty('--hx', x + '%');
+      hero.style.setProperty('--hy', y + '%');
+    });
+  }
+</script>

--- a/site/src/components/Local.astro
+++ b/site/src/components/Local.astro
@@ -9,17 +9,55 @@ const checks = [
 ];
 ---
 
-<section class="container-x py-[clamp(64px,10vw,120px)] divider-dashed">
+<section id="local" class="container-x py-[clamp(64px,10vw,120px)] divider-dashed">
   <div class="section-tag">// local-first</div>
   <h2 class="text-[clamp(26px,4vw,42px)] font-bold leading-[1.12] max-w-[22ch] mb-[14px]" style="letter-spacing: -.02em;">
     Your memory. Your machine. <span class="grad-text">Your repo</span>.
   </h2>
-  <ul class="mt-8 grid max-w-[820px] grid-cols-1 gap-x-6 gap-y-3 sm:grid-cols-2">
+  <ul class="local-list mt-8 grid max-w-[820px] grid-cols-1 gap-x-6 gap-y-3 sm:grid-cols-2">
     {checks.map((c) => (
       <li class="flex items-center gap-3 text-[15px]" style="color: var(--color-fg-soft);" data-anim="fade-up">
-        <span class="chk"></span>
-        {c}
+        <span class="chk-svg" aria-hidden="true">
+          <svg viewBox="0 0 24 24" width="22" height="22">
+            <rect x="2" y="2" width="20" height="20" rx="6" class="chk-bg" />
+            <path d="M7 12.5 10.5 16 17 9" class="chk-stroke" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" />
+          </svg>
+        </span>
+        <span>{c}</span>
       </li>
     ))}
   </ul>
 </section>
+
+<script>
+  import { animate, inView, stagger } from 'motion';
+
+  const reduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  const strokes = document.querySelectorAll<SVGPathElement>('#local .chk-stroke');
+
+  if (strokes.length) {
+    strokes.forEach((p) => {
+      const len = p.getTotalLength();
+      p.style.strokeDasharray = String(len);
+      p.style.strokeDashoffset = reduced ? '0' : String(len);
+    });
+
+    if (!reduced) {
+      const list = document.querySelector<HTMLElement>('#local .local-list');
+      if (list) {
+        inView(
+          list,
+          () => {
+            animate(
+              strokes as unknown as Element[],
+              { strokeDashoffset: [strokes[0]?.getTotalLength() ?? 30, 0] },
+              { duration: 0.5, delay: stagger(0.07), ease: [0.2, 0.7, 0.2, 1] }
+            );
+            return () => {};
+          },
+          { amount: 0.3 }
+        );
+      }
+    }
+  }
+</script>

--- a/site/src/components/Problem.astro
+++ b/site/src/components/Problem.astro
@@ -9,20 +9,62 @@ const items = [
 ];
 ---
 
-<section class="container-x py-[clamp(64px,10vw,120px)] divider-dashed">
+<section id="problem" class="container-x py-[clamp(64px,10vw,120px)] divider-dashed">
   <div class="section-tag">// the problem</div>
   <h2 class="text-[clamp(26px,4vw,42px)] font-bold leading-[1.12] max-w-[22ch] mb-[14px]" style="letter-spacing: -.02em;">
     Agents are powerful. They are also <span class="grad-text">amnesiac</span>.
   </h2>
-  <div class="mt-8 grid grid-cols-1 gap-4 md:grid-cols-3">
+  <div class="problem-grid mt-8 grid grid-cols-1 gap-4 md:grid-cols-3">
     {items.map((it) => (
-      <div class="card-base p-6" data-anim="fade-up">
-        <div class="mb-3 inline-flex h-[38px] w-[38px] items-center justify-center rounded-[10px] border" style="border-color: var(--color-border); background: linear-gradient(180deg, var(--color-surface-strong), var(--color-surface)); color: var(--color-accent);">
-          <svg viewBox="0 0 24 24" width="22" height="22"><path fill="currentColor" d={it.icon} /></svg>
+      <div class="card-base tilt-card p-6" data-anim="fade-up">
+        <div class="tilt-inner">
+          <div class="problem-icon mb-3 inline-flex h-[38px] w-[38px] items-center justify-center rounded-[10px] border" style="border-color: var(--color-border); background: linear-gradient(180deg, var(--color-surface-strong), var(--color-surface)); color: var(--color-accent);">
+            <svg viewBox="0 0 24 24" width="22" height="22"><path fill="currentColor" d={it.icon} /></svg>
+          </div>
+          <h3 class="text-[17px] mb-1.5">{it.title}</h3>
+          <p class="m-0 text-[14.5px]" style="color: var(--color-fg-mute);">{it.body}</p>
         </div>
-        <h3 class="text-[17px] mb-1.5">{it.title}</h3>
-        <p class="m-0 text-[14.5px]" style="color: var(--color-fg-mute);">{it.body}</p>
       </div>
     ))}
   </div>
 </section>
+
+<script>
+  import { animate } from 'motion';
+
+  const reduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  const hover = window.matchMedia('(hover: hover)').matches;
+  if (reduced || !hover) {
+    // nothing else to do — CSS hover styles still apply for keyboard focus
+  } else {
+    document.querySelectorAll<HTMLElement>('.tilt-card').forEach((card) => {
+      const inner = card.querySelector<HTMLElement>('.tilt-inner');
+      if (!inner) return;
+      let raf = 0;
+      card.addEventListener('pointermove', (e: PointerEvent) => {
+        const r = card.getBoundingClientRect();
+        const px = (e.clientX - r.left) / r.width;
+        const py = (e.clientY - r.top) / r.height;
+        const rx = (0.5 - py) * 8; // ±4°
+        const ry = (px - 0.5) * 10; // ±5°
+        card.style.setProperty('--mx', px * 100 + '%');
+        card.style.setProperty('--my', py * 100 + '%');
+        cancelAnimationFrame(raf);
+        raf = requestAnimationFrame(() => {
+          animate(
+            inner,
+            { rotateX: rx, rotateY: ry },
+            { type: 'spring', stiffness: 180, damping: 16, mass: 0.4 }
+          );
+        });
+      });
+      card.addEventListener('pointerleave', () => {
+        animate(
+          inner,
+          { rotateX: 0, rotateY: 0 },
+          { type: 'spring', stiffness: 160, damping: 18 }
+        );
+      });
+    });
+  }
+</script>

--- a/site/src/components/TokenSavings.astro
+++ b/site/src/components/TokenSavings.astro
@@ -1,0 +1,222 @@
+---
+const segments = [
+  { label: 'CLAUDE.md re-injected', tokens: 1500, color: 'var(--color-accent-3)' },
+  { label: 'Architecture re-explained', tokens: 500, color: 'var(--color-accent-2)' },
+  { label: 'Pitfall re-discovery', tokens: 300, color: '#f7c948' },
+  { label: 'Recap / status', tokens: 400, color: '#ff8a65' },
+];
+
+const totalBefore = segments.reduce((s, x) => s + x.tokens, 0); // 2700
+const totalAfter = 360;
+const savedPerSession = totalBefore - totalAfter; // 2340
+const withPct = Math.round((totalAfter / totalBefore) * 1000) / 10; // 13.3
+
+const breakdown = [
+  { label: 'CLAUDE.md re-injected', before: 1500, after: 0 },
+  { label: 'Architecture re-explained', before: 500, after: 80 },
+  { label: 'Pitfall re-discovered', before: 300, after: 80 },
+  { label: 'End-of-session recap', before: 400, after: 200 },
+];
+---
+
+<section id="savings" class="container-x py-[clamp(72px,11vw,128px)] divider-dashed">
+  <div class="section-tag" data-anim="fade-up">// the receipts</div>
+  <h2
+    class="text-[clamp(28px,4.4vw,48px)] font-bold leading-[1.08] max-w-[24ch] mb-[14px]"
+    style="letter-spacing: -.022em;"
+    data-anim="fade-up"
+  >
+    Your context window is not a buffet. <span class="grad-text">Stop loading the salad bar</span>.
+  </h2>
+  <p class="m-0 mb-9 max-w-[60ch] text-[clamp(15px,1.5vw,17px)]" style="color: var(--color-fg-soft);" data-anim="fade-up">
+    Without memory, every session opens with the same ~{totalBefore.toLocaleString()}-token monologue —
+    re-pasted READMEs, half-remembered decisions, and "as we discussed last Tuesday".
+    <span style="color: var(--color-fg);">Memento serves only the slice your agent actually needs.</span>
+    About {totalAfter} tokens. Same recall, less performance art.
+  </p>
+
+  <!-- Headline counter + comparison -->
+  <div class="savings-hero card-base p-[clamp(20px,3.2vw,36px)] mb-6" data-anim="fade-up">
+    <div class="flex items-baseline justify-between flex-wrap gap-3">
+      <div class="text-[12px]" style="font-family: var(--font-mono); color: var(--color-fg-mute); letter-spacing: .04em;">
+        // saved per session · conservative
+      </div>
+      <div class="text-[12px]" style="font-family: var(--font-mono); color: var(--color-fg-dim); letter-spacing: .04em;">
+        {totalBefore.toLocaleString()} → {totalAfter} tokens
+      </div>
+    </div>
+
+    <div class="mt-3 flex items-baseline gap-3 flex-wrap">
+      <span
+        class="grad-text font-extrabold tabular-nums leading-[0.95]"
+        style="font-size: clamp(64px, 12vw, 132px); letter-spacing: -.04em;"
+        data-count-to={savedPerSession}
+        aria-live="polite"
+      >0</span>
+      <span class="text-[clamp(16px,2vw,22px)] font-semibold" style="color: var(--color-fg-soft);">
+        tokens · every single session
+      </span>
+    </div>
+
+    <!-- comparison bars -->
+    <div class="mt-8 grid gap-[20px]">
+      <div class="bar-row">
+        <div class="bar-row-head">
+          <span class="bar-row-name">Without Memento</span>
+          <span class="bar-row-value tabular-nums" data-count-to={totalBefore} data-count-suffix=" t">0 t</span>
+        </div>
+        <div class="bar-track" aria-hidden="true">
+          <div class="bar-fill bar-fill-large" data-bar-target="100">
+            {segments.map((s) => (
+              <div
+                class="bar-seg"
+                style={`flex-grow: ${s.tokens}; background: linear-gradient(180deg, ${s.color}, color-mix(in oklab, ${s.color} 75%, transparent));`}
+                title={`${s.label} · ~${s.tokens} tokens`}
+              >
+                <span class="bar-seg-label">{s.label.split(' ')[0]} · {s.tokens.toLocaleString()}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <div class="bar-row">
+        <div class="bar-row-head">
+          <span class="bar-row-name" style="color: var(--color-accent);">With Memento</span>
+          <span class="bar-row-value tabular-nums" data-count-to={totalAfter} data-count-suffix=" t">0 t</span>
+        </div>
+        <div class="bar-track" aria-hidden="true">
+          <div class="bar-fill bar-fill-small" data-bar-target={withPct}></div>
+        </div>
+      </div>
+    </div>
+
+    <!-- breakdown table (semantic + visible) -->
+    <details class="savings-breakdown mt-7">
+      <summary>
+        <span>see the breakdown</span>
+        <svg viewBox="0 0 24 24" width="14" height="14" aria-hidden="true" class="caret">
+          <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+        </svg>
+      </summary>
+      <table class="breakdown-table">
+        <thead>
+          <tr>
+            <th scope="col">Where the tokens go</th>
+            <th scope="col" class="num">Without</th>
+            <th scope="col" class="num">With</th>
+            <th scope="col" class="num">Saved</th>
+          </tr>
+        </thead>
+        <tbody>
+          {breakdown.map((r) => (
+            <tr>
+              <td>{r.label}</td>
+              <td class="num tabular-nums">~{r.before.toLocaleString()}</td>
+              <td class="num tabular-nums">{r.after === 0 ? '0' : '~' + r.after.toLocaleString()}</td>
+              <td class="num tabular-nums saved">~{(r.before - r.after).toLocaleString()}</td>
+            </tr>
+          ))}
+          <tr class="total">
+            <td>Per-session prelude</td>
+            <td class="num tabular-nums">~{totalBefore.toLocaleString()}</td>
+            <td class="num tabular-nums">~{totalAfter.toLocaleString()}</td>
+            <td class="num tabular-nums saved">~{savedPerSession.toLocaleString()}</td>
+          </tr>
+        </tbody>
+      </table>
+    </details>
+  </div>
+
+  <!-- scaling cards -->
+  <div class="grid grid-cols-1 md:grid-cols-2 gap-[14px]">
+    <div class="card-base scale-card p-[clamp(18px,2.6vw,28px)]" data-anim="fade-up">
+      <div class="text-[12px]" style="font-family: var(--font-mono); color: var(--color-fg-mute); letter-spacing: .04em;">
+        // solo dev · ~80 sessions / month
+      </div>
+      <div class="mt-2 flex items-baseline gap-2 flex-wrap">
+        <span
+          class="grad-text font-extrabold tabular-nums leading-none"
+          style="font-size: clamp(40px, 6vw, 64px); letter-spacing: -.03em;"
+          data-count-to="190000"
+        >0</span>
+        <span class="text-[14px] font-semibold" style="color: var(--color-fg-soft);">tokens / month</span>
+      </div>
+      <p class="m-0 mt-2 text-[13px]" style="color: var(--color-fg-mute);">
+        Roughly 4 sessions a day, every working day, that you don't pay to re-explain.
+      </p>
+    </div>
+    <div class="card-base scale-card p-[clamp(18px,2.6vw,28px)]" data-anim="fade-up">
+      <div class="text-[12px]" style="font-family: var(--font-mono); color: var(--color-fg-mute); letter-spacing: .04em;">
+        // 5-person team · ~400 sessions / month
+      </div>
+      <div class="mt-2 flex items-baseline gap-2 flex-wrap">
+        <span
+          class="grad-text font-extrabold tabular-nums leading-none"
+          style="font-size: clamp(40px, 6vw, 64px); letter-spacing: -.03em;"
+          data-count-to="940000"
+        >0</span>
+        <span class="text-[14px] font-semibold" style="color: var(--color-fg-soft);">tokens / month</span>
+      </div>
+      <p class="m-0 mt-2 text-[13px]" style="color: var(--color-fg-mute);">
+        Nearly a million tokens of pure prelude, recovered. Spend them on actual code.
+      </p>
+    </div>
+  </div>
+
+  <p class="mt-5 text-[12.5px]" style="font-family: var(--font-mono); color: var(--color-fg-dim); letter-spacing: .02em;" data-anim="fade-up">
+    // numbers deliberately conservative. real <code class="inline-code">CLAUDE.md</code> files routinely hit 3–5k tokens. savings scale with project age.
+  </p>
+</section>
+
+<script>
+  import { animate, inView } from 'motion';
+
+  const reduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  const fmt = new Intl.NumberFormat();
+
+  const root = document.getElementById('savings');
+  if (root) {
+    // count-up
+    const counters = root.querySelectorAll<HTMLElement>('[data-count-to]');
+    counters.forEach((el) => {
+      const to = Number(el.dataset.countTo);
+      const suffix = el.dataset.countSuffix ?? '';
+      const setVal = (n: number) => { el.textContent = fmt.format(n) + suffix; };
+
+      if (reduced) {
+        setVal(to);
+        return;
+      }
+      setVal(0);
+      // pick a duration that scales with magnitude so big numbers don't blur past
+      const duration = to >= 100_000 ? 1.8 : to >= 10_000 ? 1.5 : 1.2;
+      inView(el, () => {
+        animate(0, to, {
+          duration,
+          ease: [0.2, 0.7, 0.2, 1],
+          onUpdate: (v: number) => setVal(Math.round(v)),
+        });
+        return () => {};
+      }, { amount: 0.5 });
+    });
+
+    // bar fills
+    const bars = root.querySelectorAll<HTMLElement>('[data-bar-target]');
+    bars.forEach((el) => {
+      const target = Number(el.dataset.barTarget); // percent 0..100
+      el.style.width = target + '%';
+      if (reduced) return;
+      el.style.transformOrigin = 'left center';
+      el.style.transform = 'scaleX(0)';
+      inView(el, () => {
+        animate(
+          el,
+          { transform: ['scaleX(0)', 'scaleX(1)'] },
+          { duration: 1.0, ease: [0.2, 0.7, 0.2, 1], delay: 0.18 }
+        );
+        return () => {};
+      }, { amount: 0.4 });
+    });
+  }
+</script>

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -3,6 +3,7 @@ import Layout from '../layouts/Layout.astro';
 import Nav from '../components/Nav.astro';
 import Hero from '../components/Hero.astro';
 import Problem from '../components/Problem.astro';
+import TokenSavings from '../components/TokenSavings.astro';
 import Features from '../components/Features.astro';
 import How from '../components/How.astro';
 import Local from '../components/Local.astro';
@@ -17,6 +18,7 @@ import Animations from '../components/Animations.astro';
   <main id="top">
     <Hero />
     <Problem />
+    <TokenSavings />
     <Features />
     <How />
     <Local />

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -478,6 +478,325 @@
                 background .25s var(--ease-snap);
   }
   .nav-shell.scrolled { border-bottom-color: var(--color-border); }
+
+  /* ============================================================
+     ambient drifting orbs (replaces static bg-glow scroll parallax)
+     ============================================================ */
+  .orbs {
+    position: fixed;
+    inset: 0;
+    z-index: -1;
+    pointer-events: none;
+    overflow: hidden;
+  }
+  .orb {
+    position: absolute;
+    border-radius: 50%;
+    filter: blur(60px);
+    opacity: .35;
+    will-change: transform;
+  }
+  .orb-1 {
+    top: -10%; left: 8%;
+    width: 50vw; height: 50vw;
+    background: radial-gradient(closest-side,
+      color-mix(in oklab, var(--color-accent) 55%, transparent), transparent 70%);
+  }
+  .orb-2 {
+    top: -5%; right: -5%;
+    width: 45vw; height: 45vw;
+    background: radial-gradient(closest-side,
+      color-mix(in oklab, var(--color-accent-2) 50%, transparent), transparent 70%);
+  }
+  .orb-3 {
+    bottom: -15%; left: 30%;
+    width: 55vw; height: 55vw;
+    background: radial-gradient(closest-side,
+      color-mix(in oklab, var(--color-accent-3) 35%, transparent), transparent 70%);
+    opacity: .25;
+  }
+  [data-theme='light'] .orb { opacity: .22; }
+  [data-theme='light'] .orb-3 { opacity: .18; }
+
+  /* ============================================================
+     scroll progress bar (fixed, top of viewport)
+     ============================================================ */
+  .scroll-progress {
+    position: fixed;
+    top: 0; left: 0; right: 0;
+    height: 2px;
+    z-index: 60;
+    pointer-events: none;
+  }
+  .scroll-progress > span {
+    display: block;
+    height: 100%;
+    width: 100%;
+    background: linear-gradient(90deg,
+      var(--color-accent),
+      var(--color-accent-2) 60%,
+      var(--color-accent-3));
+    transform: scaleX(0);
+    transform-origin: left center;
+    box-shadow: 0 0 12px color-mix(in oklab, var(--color-accent) 50%, transparent);
+  }
+
+  /* ============================================================
+     hero: cursor spotlight + savings chip
+     ============================================================ */
+  #hero {
+    --hx: 50%;
+    --hy: 30%;
+  }
+  #hero::before {
+    content: '';
+    position: absolute;
+    inset: -10% -10% 0 -10%;
+    background: radial-gradient(420px 240px at var(--hx) var(--hy),
+      color-mix(in oklab, var(--color-accent) 18%, transparent), transparent 60%);
+    pointer-events: none;
+    z-index: -1;
+    transition: opacity .3s var(--ease-snap);
+  }
+  .hero-savings-chip {
+    background: color-mix(in oklab, var(--color-surface-strong) 90%, var(--color-accent-glow));
+    border-color: color-mix(in oklab, var(--color-accent) 25%, var(--color-border));
+    color: var(--color-fg);
+    text-decoration: none;
+    transition: transform .2s var(--ease-snap),
+                border-color .2s var(--ease-snap),
+                box-shadow .25s var(--ease-snap);
+    box-shadow: 0 0 0 0 var(--color-accent-glow);
+  }
+  .hero-savings-chip:hover {
+    transform: translateY(-1px);
+    border-color: color-mix(in oklab, var(--color-accent) 45%, var(--color-border));
+    box-shadow: 0 8px 28px -10px var(--color-accent-glow);
+  }
+  .hero-savings-spark {
+    width: 8px; height: 8px;
+    border-radius: 50%;
+    background: var(--color-accent);
+    box-shadow:
+      0 0 0 3px color-mix(in oklab, var(--color-accent) 22%, transparent),
+      0 0 14px var(--color-accent);
+    animation: pulse 2.4s ease-in-out infinite;
+  }
+  /* on small screens, drop the secondary stat to keep the chip tight */
+  @media (max-width: 640px) {
+    .hero-savings-chip {
+      font-size: 12px;
+      flex-wrap: wrap;
+      justify-content: center;
+      max-width: 92%;
+    }
+  }
+
+  /* ============================================================
+     problem cards: 3D tilt
+     ============================================================ */
+  .problem-grid { perspective: 900px; }
+  .tilt-card { transform-style: preserve-3d; }
+  .tilt-card .tilt-inner {
+    transform-style: preserve-3d;
+    transition: transform .25s var(--ease-snap);
+    will-change: transform;
+  }
+  .tilt-card {
+    position: relative;
+    overflow: hidden;
+  }
+  .tilt-card::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    background: radial-gradient(280px 200px at var(--mx, 50%) var(--my, 30%),
+      color-mix(in oklab, var(--color-accent) 22%, transparent), transparent 65%);
+    opacity: 0;
+    transition: opacity .3s var(--ease-snap);
+    pointer-events: none;
+  }
+  .tilt-card:hover::after { opacity: .7; }
+  .tilt-card:hover .problem-icon {
+    color: var(--color-accent);
+    border-color: color-mix(in oklab, var(--color-accent) 30%, var(--color-border));
+  }
+
+  /* ============================================================
+     local: animated checkmark
+     ============================================================ */
+  .chk-svg {
+    flex-shrink: 0;
+    color: var(--color-bg);
+    width: 22px; height: 22px;
+    display: inline-flex;
+  }
+  .chk-svg .chk-bg {
+    fill: var(--color-accent);
+  }
+  .chk-svg svg {
+    filter: drop-shadow(0 0 0 4px color-mix(in oklab, var(--color-accent) 12%, transparent));
+  }
+  [data-theme='light'] .chk-svg { color: #fff; }
+
+  /* ============================================================
+     token savings section
+     ============================================================ */
+  #savings .savings-hero {
+    position: relative;
+    overflow: hidden;
+    background: linear-gradient(180deg,
+      color-mix(in oklab, var(--color-surface-strong) 90%, var(--color-accent-glow)),
+      var(--color-surface));
+    border-color: color-mix(in oklab, var(--color-accent) 18%, var(--color-border));
+  }
+  #savings .savings-hero::before {
+    content: '';
+    position: absolute;
+    inset: -1px;
+    border-radius: inherit;
+    padding: 1px;
+    background: linear-gradient(135deg,
+      var(--color-accent), transparent 40%, var(--color-accent-2) 80%);
+    -webkit-mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+    -webkit-mask-composite: xor;
+            mask-composite: exclude;
+    opacity: .4;
+    pointer-events: none;
+  }
+  #savings .bar-row {
+    display: grid;
+    gap: 8px;
+  }
+  #savings .bar-row-head {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: 8px;
+    font-size: 13px;
+  }
+  #savings .bar-row-name {
+    font-weight: 600;
+    color: var(--color-fg);
+  }
+  #savings .bar-row-value {
+    font-family: var(--font-mono);
+    color: var(--color-fg-mute);
+    font-size: 12.5px;
+  }
+  #savings .bar-track {
+    width: 100%;
+    height: 30px;
+    border-radius: 8px;
+    background: color-mix(in oklab, var(--color-fg-dim) 12%, transparent);
+    overflow: hidden;
+    border: 1px solid var(--color-border);
+  }
+  #savings .bar-fill {
+    height: 100%;
+    border-radius: 7px;
+    will-change: transform;
+  }
+  #savings .bar-fill-large {
+    display: flex;
+    width: 100%;
+  }
+  #savings .bar-seg {
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    overflow: hidden;
+    font-family: var(--font-mono);
+    font-size: 11px;
+    color: rgba(10, 12, 18, .82);
+    font-weight: 600;
+    white-space: nowrap;
+    text-shadow: 0 1px 0 rgba(255, 255, 255, .25);
+  }
+  #savings .bar-seg + .bar-seg {
+    border-left: 1px solid rgba(10, 12, 18, .12);
+  }
+  [data-theme='dark'] #savings .bar-seg + .bar-seg {
+    border-left-color: rgba(0, 0, 0, .25);
+  }
+  @media (max-width: 540px) {
+    #savings .bar-seg-label { display: none; }
+  }
+  #savings .bar-fill-small {
+    background: linear-gradient(90deg,
+      var(--color-accent),
+      color-mix(in oklab, var(--color-accent) 70%, var(--color-accent-2)));
+    box-shadow:
+      0 0 0 1px color-mix(in oklab, var(--color-accent) 60%, transparent),
+      0 0 24px color-mix(in oklab, var(--color-accent) 35%, transparent);
+  }
+
+  /* breakdown table */
+  #savings .savings-breakdown {
+    border-top: 1px dashed var(--color-border);
+    padding-top: 18px;
+  }
+  #savings .savings-breakdown summary {
+    cursor: pointer;
+    list-style: none;
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    font-family: var(--font-mono);
+    font-size: 12.5px;
+    color: var(--color-fg-mute);
+    user-select: none;
+    transition: color .15s var(--ease-snap);
+  }
+  #savings .savings-breakdown summary::-webkit-details-marker { display: none; }
+  #savings .savings-breakdown summary:hover { color: var(--color-fg); }
+  #savings .savings-breakdown summary .caret {
+    transition: transform .25s var(--ease-snap);
+  }
+  #savings .savings-breakdown[open] summary .caret { transform: rotate(180deg); }
+  #savings .breakdown-table {
+    margin-top: 14px;
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 13px;
+  }
+  #savings .breakdown-table th,
+  #savings .breakdown-table td {
+    padding: 10px 12px;
+    text-align: left;
+    border-bottom: 1px solid var(--color-border);
+  }
+  #savings .breakdown-table th {
+    font-family: var(--font-mono);
+    font-weight: 500;
+    color: var(--color-fg-mute);
+    font-size: 11.5px;
+    letter-spacing: .04em;
+    text-transform: uppercase;
+  }
+  #savings .breakdown-table td { color: var(--color-fg-soft); }
+  #savings .breakdown-table .num { text-align: right; font-family: var(--font-mono); }
+  #savings .breakdown-table .saved { color: var(--color-accent); font-weight: 600; }
+  #savings .breakdown-table tr.total td {
+    border-top: 1px solid var(--color-border-strong);
+    border-bottom: none;
+    color: var(--color-fg);
+    font-weight: 600;
+    padding-top: 14px;
+  }
+  #savings .scale-card {
+    background: linear-gradient(180deg,
+      color-mix(in oklab, var(--color-surface-strong) 80%, var(--color-accent-glow)),
+      var(--color-surface));
+  }
+}
+
+/* reduce-motion overrides for orbs and progress bar */
+@media (prefers-reduced-motion: reduce) {
+  .orb { animation: none !important; }
+  .scroll-progress > span { transform: scaleX(1) !important; }
 }
 
 /* reveal preset for Motion-controlled elements */


### PR DESCRIPTION
Adds a dedicated "the receipts" section between Problem and Features that
hammers home the README's conservative projections: 2,340 tokens saved per
session, ~190k/mo for solo devs, ~940k/mo for 5-person teams. Each number
animates in via IntersectionObserver-gated count-up, the per-session
breakdown renders as a segmented before/after bar comparison (2,700 vs 360),
and the full table is preserved as a semantic <table> in a <details>.

Motion polish across the site:
- Hero: animated savings teaser chip above the CTAs, magnetic primary CTA,
  cursor-tracking spotlight
- Background: replaced static parallax glow with three drifting orbs on
  long-loop mirrored springs
- Nav: 2px scroll-progress bar wired through motion's scroll() (rAF)
- Terminal: one-shot type-on cascade on first viewport entry
- Problem cards: 3D tilt with cursor-tracked rotateX/rotateY (spring) and
  spotlight halo
- Local checks: SVG checkmarks with stroke-draw animation, staggered

All animations gate on prefers-reduced-motion (counters jump to final value,
orbs are static, no tilt, no typing). Hover-only effects gate on (hover:hover).