### PR TITLE
ci: pass NPM_TOKEN to publish step so auth is sent to registry

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -49,6 +49,8 @@ jobs:
 
       - name: Publish to npm
         run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Configure git
         run: |


### PR DESCRIPTION
setup-node configures the registry URL but only injects authentication
into npm when NODE_AUTH_TOKEN is present on the publishing step.
Without it, npm publish runs anonymously and the registry returns 404
for scoped packages, which is what the v2.1.3 release saw.

https://claude.ai/code/session_01WZ8hepzyiXwziRufHqZDNp