### PR TITLE
ci: drop --auto from release PR merge

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -85,6 +85,6 @@ jobs:
             --head "${{ steps.commit.outputs.branch }}" \
             --title "chore(release): v${{ inputs.version }}" \
             --body "Automated version bump for v${{ inputs.version }}. Already published to npm and tagged."
-          gh pr merge "${{ steps.commit.outputs.branch }}" --squash --delete-branch --auto
+          gh pr merge "${{ steps.commit.outputs.branch }}" --squash --delete-branch
         env:
           GH_TOKEN: ${{ secrets.RELEASE_PAT }}


### PR DESCRIPTION
The repo has no branch protection rules on master, so
`gh pr merge --auto` fails with "Protected branch rules not configured
for this branch (enablePullRequestAutoMerge)". Since the release has
already been published to npm and tagged by the time we open the PR,
just merge immediately.

https://claude.ai/code/session_01QUyr82kVyDh7BUyEir2T7d