### PR TITLE
feat(graph): typed-edge knowledge graph over memories (issue #27)

### DIFF
--- a/src/db/database.ts
+++ b/src/db/database.ts
@@ -348,6 +348,29 @@ CREATE TABLE IF NOT EXISTS sync_file_hashes (
 CREATE INDEX IF NOT EXISTS idx_sync_file_hashes_project ON sync_file_hashes(project_id);
 `,
   },
+  {
+    version: 8,
+    name: "memory_edges",
+    sql: `
+CREATE TABLE IF NOT EXISTS memory_edges (
+  from_id    TEXT NOT NULL REFERENCES memories(id) ON DELETE CASCADE,
+  to_id      TEXT NOT NULL REFERENCES memories(id) ON DELETE CASCADE,
+  edge_type  TEXT NOT NULL,
+  weight     REAL NOT NULL DEFAULT 1.0,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  PRIMARY KEY (from_id, to_id, edge_type)
+);
+
+CREATE INDEX IF NOT EXISTS idx_memory_edges_from ON memory_edges(from_id);
+CREATE INDEX IF NOT EXISTS idx_memory_edges_to ON memory_edges(to_id);
+CREATE INDEX IF NOT EXISTS idx_memory_edges_type ON memory_edges(edge_type);
+
+INSERT OR IGNORE INTO memory_edges (from_id, to_id, edge_type, weight, created_at)
+  SELECT id, supersedes_memory_id, 'supersedes', 1.0, created_at
+  FROM memories
+  WHERE supersedes_memory_id IS NOT NULL;
+`,
+  },
 ];
 
 const FTS_TRIGGERS_SQL = `

--- a/src/db/edges.ts
+++ b/src/db/edges.ts
@@ -1,0 +1,163 @@
+// src/db/edges.ts
+import type Database from "better-sqlite3";
+import { nowIso } from "./database.js";
+
+export type EdgeType =
+  | "relates_to"
+  | "supersedes"
+  | "caused_by"
+  | "mitigated_by"
+  | "references"
+  | "implements";
+
+export const ALLOWED_EDGE_TYPES: EdgeType[] = [
+  "relates_to",
+  "supersedes",
+  "caused_by",
+  "mitigated_by",
+  "references",
+  "implements",
+];
+
+export interface EdgeRow {
+  from_id: string;
+  to_id: string;
+  edge_type: EdgeType;
+  weight: number;
+  created_at: string;
+}
+
+export class EdgesRepo {
+  constructor(private db: Database.Database) {}
+
+  link(fromId: string, toId: string, type: EdgeType, weight: number = 1.0): void {
+    if (fromId === toId) {
+      throw new Error("Self-edges are not allowed");
+    }
+    if (!ALLOWED_EDGE_TYPES.includes(type)) {
+      throw new Error(`Unknown edge type: ${type}`);
+    }
+    this.db.prepare(`
+      INSERT OR REPLACE INTO memory_edges (from_id, to_id, edge_type, weight, created_at)
+      VALUES (?, ?, ?, ?, ?)
+    `).run(fromId, toId, type, weight, nowIso());
+  }
+
+  unlink(fromId: string, toId: string, type: EdgeType): boolean {
+    const result = this.db.prepare(`
+      DELETE FROM memory_edges WHERE from_id = ? AND to_id = ? AND edge_type = ?
+    `).run(fromId, toId, type);
+    return result.changes > 0;
+  }
+
+  outgoing(id: string, types?: EdgeType[]): EdgeRow[] {
+    if (types && types.length > 0) {
+      const placeholders = types.map(() => "?").join(",");
+      return this.db.prepare(`
+        SELECT * FROM memory_edges WHERE from_id = ? AND edge_type IN (${placeholders})
+        ORDER BY edge_type, to_id
+      `).all(id, ...types) as EdgeRow[];
+    }
+    return this.db.prepare(`
+      SELECT * FROM memory_edges WHERE from_id = ? ORDER BY edge_type, to_id
+    `).all(id) as EdgeRow[];
+  }
+
+  incoming(id: string, types?: EdgeType[]): EdgeRow[] {
+    if (types && types.length > 0) {
+      const placeholders = types.map(() => "?").join(",");
+      return this.db.prepare(`
+        SELECT * FROM memory_edges WHERE to_id = ? AND edge_type IN (${placeholders})
+        ORDER BY edge_type, from_id
+      `).all(id, ...types) as EdgeRow[];
+    }
+    return this.db.prepare(`
+      SELECT * FROM memory_edges WHERE to_id = ? ORDER BY edge_type, from_id
+    `).all(id) as EdgeRow[];
+  }
+
+  subgraph(
+    rootId: string,
+    depth: number,
+    types?: EdgeType[],
+    direction: "out" | "in" | "both" = "both"
+  ): { nodes: string[]; edges: EdgeRow[] } {
+    const visited = new Set<string>();
+    const allEdges: EdgeRow[] = [];
+    visited.add(rootId);
+
+    let frontier = [rootId];
+
+    for (let d = 0; d < depth; d++) {
+      const nextFrontier: string[] = [];
+      for (const nodeId of frontier) {
+        const outEdges = direction !== "in" ? this.outgoing(nodeId, types) : [];
+        const inEdges = direction !== "out" ? this.incoming(nodeId, types) : [];
+
+        for (const edge of outEdges) {
+          allEdges.push(edge);
+          if (!visited.has(edge.to_id)) {
+            visited.add(edge.to_id);
+            nextFrontier.push(edge.to_id);
+          }
+        }
+        for (const edge of inEdges) {
+          allEdges.push(edge);
+          if (!visited.has(edge.from_id)) {
+            visited.add(edge.from_id);
+            nextFrontier.push(edge.from_id);
+          }
+        }
+      }
+      frontier = nextFrontier;
+      if (frontier.length === 0) break;
+    }
+
+    return { nodes: Array.from(visited), edges: allEdges };
+  }
+
+  shortestPath(
+    fromId: string,
+    toId: string,
+    maxHops: number,
+    types?: EdgeType[]
+  ): string[] | null {
+    if (fromId === toId) return [fromId];
+
+    const visited = new Map<string, string | null>();
+    visited.set(fromId, null);
+    let frontier = [fromId];
+
+    for (let hop = 0; hop < maxHops; hop++) {
+      const nextFrontier: string[] = [];
+      for (const nodeId of frontier) {
+        const outEdges = this.outgoing(nodeId, types);
+        const inEdges = this.incoming(nodeId, types);
+        const neighbors = [
+          ...outEdges.map(e => e.to_id),
+          ...inEdges.map(e => e.from_id),
+        ];
+        for (const neighbor of neighbors) {
+          if (!visited.has(neighbor)) {
+            visited.set(neighbor, nodeId);
+            if (neighbor === toId) {
+              // Reconstruct path
+              const path: string[] = [];
+              let cur: string | null = toId;
+              while (cur !== null) {
+                path.unshift(cur);
+                cur = visited.get(cur) ?? null;
+              }
+              return path;
+            }
+            nextFrontier.push(neighbor);
+          }
+        }
+      }
+      frontier = nextFrontier;
+      if (frontier.length === 0) break;
+    }
+
+    return null;
+  }
+}

--- a/src/db/memories.ts
+++ b/src/db/memories.ts
@@ -102,17 +102,27 @@ export class MemoriesRepo {
     // Issue #3: claude_session_id column added in migration v5.
     // Issue #4: has_private column added in migration v6.
     const hasPrivateFlag = hasPrivate(cleanBody) ? 1 : 0;
-    this.db.prepare(`
-      INSERT INTO memories (id, project_id, memory_type, scope, title, body, tags,
-                            importance_score, is_pinned, supersedes_memory_id, source,
-                            claude_session_id, has_private,
-                            created_at, updated_at, last_accessed_at)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-    `).run(id, projectId, params.memoryType ?? "fact", params.scope ?? "project",
-           cleanTitle, cleanBody, tagsStr, params.importance ?? 0.5,
-           params.pin ? 1 : 0, params.supersedesId || null, params.source ?? "user",
-           params.claudeSessionId ?? null, hasPrivateFlag,
-           now, now, now);
+    this.db.transaction(() => {
+      this.db.prepare(`
+        INSERT INTO memories (id, project_id, memory_type, scope, title, body, tags,
+                              importance_score, is_pinned, supersedes_memory_id, source,
+                              claude_session_id, has_private,
+                              created_at, updated_at, last_accessed_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `).run(id, projectId, params.memoryType ?? "fact", params.scope ?? "project",
+             cleanTitle, cleanBody, tagsStr, params.importance ?? 0.5,
+             params.pin ? 1 : 0, params.supersedesId || null, params.source ?? "user",
+             params.claudeSessionId ?? null, hasPrivateFlag,
+             now, now, now);
+
+      // Issue #27: also insert a 'supersedes' edge into memory_edges for atomicity.
+      if (params.supersedesId) {
+        this.db.prepare(`
+          INSERT OR IGNORE INTO memory_edges (from_id, to_id, edge_type, weight, created_at)
+          VALUES (?, ?, 'supersedes', 1.0, ?)
+        `).run(id, params.supersedesId, now);
+      }
+    })();
     return id;
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import { DecisionsRepo } from "./db/decisions.js";
 import { PitfallsRepo } from "./db/pitfalls.js";
 import { SessionsRepo } from "./db/sessions.js";
 import { EmbeddingsRepo } from "./db/embeddings.js";
+import { EdgesRepo } from "./db/edges.js";
 import { loadConfig, getDefaultConfigPath, getDefaultDbPath } from "./lib/config.js";
 import { createLogger, logLevelFromEnv } from "./lib/logger.js";
 import { handleMemoryStore } from "./tools/memory-store.js";
@@ -22,6 +23,10 @@ import { handleMemoryCompress } from "./tools/memory-compress.js";
 import { handleMemoryUpdate } from "./tools/memory-update.js";
 import { handleMemoryPin } from "./tools/memory-pin.js";
 import { handleMemoryExport, handleMemoryImport } from "./tools/memory-transfer.js";
+import { handleMemoryLink } from "./tools/memory-link.js";
+import { handleMemoryUnlink } from "./tools/memory-unlink.js";
+import { handleMemoryGraph } from "./tools/memory-graph.js";
+import { handleMemoryPath } from "./tools/memory-path.js";
 import { AnalyticsTracker, installFlushOnExit } from "./analytics/tracker.js";
 import { cleanupExpiredAnalytics } from "./analytics/retention.js";
 import { runCompressionCycle } from "./engine/compressor.js";
@@ -39,6 +44,7 @@ const decRepo = new DecisionsRepo(db);
 const pitRepo = new PitfallsRepo(db);
 const sessRepo = new SessionsRepo(db);
 const embRepo = new EmbeddingsRepo(db);
+const edgesRepo = new EdgesRepo(db);
 const analyticsTracker = new AnalyticsTracker(db, { flushThreshold: config.analytics.flushThreshold });
 const disposeFlush = installFlushOnExit(analyticsTracker);
 
@@ -382,6 +388,79 @@ server.tool(
   },
   async (params) => ({
     content: [{ type: "text" as const, text: await handleMemoryImport(db, params) }],
+  })
+);
+
+const edgeTypeEnum = z.enum(["relates_to", "supersedes", "caused_by", "mitigated_by", "references", "implements"]);
+
+server.tool(
+  "memory_link",
+  [
+    "Create a typed edge between two memories. Edge types: relates_to | supersedes | caused_by | mitigated_by | references | implements.",
+    "Use memory_search first to find the ids, then memory_link to connect them.",
+    "Optional weight (0-1) signals edge strength (default 1.0).",
+    "Re-linking an existing (from,to,type) triple updates its weight.",
+  ].join(" "),
+  {
+    from_id: z.string(),
+    to_id: z.string(),
+    edge_type: edgeTypeEnum,
+    weight: z.number().min(0).max(1).default(1.0),
+  },
+  async (params) => ({
+    content: [{ type: "text" as const, text: await handleMemoryLink(memRepo, edgesRepo, params) }],
+  })
+);
+
+server.tool(
+  "memory_unlink",
+  "Remove a typed edge between two memories. Provide the same from_id, to_id, and edge_type used when the edge was created.",
+  {
+    from_id: z.string(),
+    to_id: z.string(),
+    edge_type: edgeTypeEnum,
+  },
+  async (params) => ({
+    content: [{ type: "text" as const, text: await handleMemoryUnlink(edgesRepo, params) }],
+  })
+);
+
+server.tool(
+  "memory_graph",
+  [
+    "Explore the knowledge graph around a memory (BFS up to depth hops).",
+    "Returns neighbour nodes with typed edges. Edge types: relates_to | supersedes | caused_by | mitigated_by | references | implements.",
+    "Chain: memory_search → memory_graph to map related concepts.",
+    "direction='out' follows outgoing edges only; 'in' follows incoming; 'both' (default) follows all.",
+    "Depth 0 returns just the root node; max depth is 5.",
+  ].join(" "),
+  {
+    id: z.string(),
+    depth: z.number().int().min(0).max(5).default(2),
+    edge_types: z.array(edgeTypeEnum).optional(),
+    direction: z.enum(["out", "in", "both"]).default("both"),
+  },
+  async (params) => ({
+    content: [{ type: "text" as const, text: await handleMemoryGraph(memRepo, edgesRepo, params) }],
+  })
+);
+
+server.tool(
+  "memory_path",
+  [
+    "Find the shortest path between two memories in the knowledge graph.",
+    "Returns the chain of memory ids and edge types connecting from_id to to_id.",
+    "Chain: memory_search → memory_path to trace cause-effect or dependency chains.",
+    "max_hops limits BFS depth (default 4, max 10).",
+  ].join(" "),
+  {
+    from_id: z.string(),
+    to_id: z.string(),
+    max_hops: z.number().int().min(1).max(10).default(4),
+    edge_types: z.array(edgeTypeEnum).optional(),
+  },
+  async (params) => ({
+    content: [{ type: "text" as const, text: await handleMemoryPath(memRepo, edgesRepo, params) }],
   })
 );
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import { handleMemoryGet } from "./tools/memory-get.js";
 import { handleMemoryTimeline } from "./tools/memory-timeline.js";
 import { handleMemoryList } from "./tools/memory-list.js";
 import { handleMemoryDelete } from "./tools/memory-delete.js";
+import { handleMemoryDedupCheck } from "./tools/memory-dedup-check.js";
 import { handleDecisionsLog } from "./tools/decisions-log.js";
 import { handlePitfallsLog } from "./tools/pitfalls-log.js";
 import { handleMemoryAnalytics } from "./tools/analytics-tools.js";
@@ -35,6 +36,7 @@ import { configureFileMemoryCache } from "./lib/file-memory.js";
 import { promoteImportanceFromUtility } from "./engine/importance-promoter.js";
 import { collectPoliciesPerProject } from "./lib/policy.js";
 import { logDedupOnFirstUse } from "./engine/embeddings/dedup.js";
+import { createProvider } from "./engine/embeddings/provider.js";
 
 const log = createLogger(logLevelFromEnv());
 const config = loadConfig(getDefaultConfigPath());
@@ -45,6 +47,7 @@ const pitRepo = new PitfallsRepo(db);
 const sessRepo = new SessionsRepo(db);
 const embRepo = new EmbeddingsRepo(db);
 const edgesRepo = new EdgesRepo(db);
+const dedupProvider = createProvider(config.search.embeddings);
 const analyticsTracker = new AnalyticsTracker(db, { flushThreshold: config.analytics.flushThreshold });
 const disposeFlush = installFlushOnExit(analyticsTracker);
 
@@ -244,6 +247,26 @@ server.tool(
   },
   async (params) => ({
     content: [{ type: "text" as const, text: await handleMemoryTimeline(memRepo, params) }],
+  })
+);
+
+server.tool(
+  "memory_dedup_check",
+  [
+    "Check if content is a near-duplicate of existing memories before storing.",
+    "Returns up to N matches above the cosine similarity threshold.",
+    "~50 tokens per result. Cheap pre-flight before memory_store.",
+    "If embeddings are disabled, returns a clear no-op message."
+  ].join(" "),
+  {
+    content: z.string(),
+    title: z.string().optional(),
+    project_path: z.string().optional(),
+    threshold: z.number().min(0).max(1).optional(),
+    limit: z.number().int().min(1).max(20).default(5),
+  },
+  async (params) => ({
+    content: [{ type: "text" as const, text: await handleMemoryDedupCheck(db, memRepo, embRepo, dedupProvider, config, params) }]
   })
 );
 

--- a/src/tools/memory-dedup-check.ts
+++ b/src/tools/memory-dedup-check.ts
@@ -1,0 +1,80 @@
+import type Database from "better-sqlite3";
+import type { MemoriesRepo } from "../db/memories.js";
+import type { EmbeddingsRepo } from "../db/embeddings.js";
+import type { EmbeddingProvider } from "../engine/embeddings/provider.js";
+import type { Config } from "../lib/config.js";
+import { findDuplicate } from "../engine/embeddings/dedup.js";
+import { estimateTokensV2 } from "../engine/token-estimator.js";
+
+export interface DedupCheckParams {
+  content: string;
+  title?: string;
+  project_path?: string;
+  threshold?: number;     // overrides config.search.embeddings.dedupThreshold
+  limit?: number;         // default 5, max 20
+}
+
+export async function handleMemoryDedupCheck(
+  db: Database.Database,
+  memRepo: MemoriesRepo,
+  embRepo: EmbeddingsRepo,
+  provider: EmbeddingProvider | null,
+  config: Config,
+  params: DedupCheckParams,
+): Promise<string> {
+  // If embeddings disabled or no provider, return no-op message.
+  if (!config.search.embeddings.enabled || !provider) {
+    return "Dedup unavailable: embeddings disabled (set search.embeddings.enabled = true and provide API key).";
+  }
+
+  // Compute threshold and limit.
+  const threshold = params.threshold ?? config.search.embeddings.dedupThreshold;
+  const limit = Math.min(params.limit ?? 5, 20);
+
+  // Resolve project ID if project_path provided.
+  let projectId: string | null = null;
+  if (params.project_path) {
+    const row = db.prepare("SELECT id FROM projects WHERE root_path = ?").get(params.project_path) as
+      | { id: string }
+      | undefined;
+    projectId = row?.id ?? null;
+  }
+
+  // Concatenate title and content.
+  const text = params.title ? `${params.title}\n\n${params.content}` : params.content;
+
+  // Call findDuplicate.
+  const { duplicate, candidates } = await findDuplicate(
+    db,
+    embRepo,
+    provider,
+    text,
+    projectId,
+    threshold,
+  );
+
+  // Combine and slice results.
+  const hits = [duplicate, ...candidates].filter((h) => h !== null).slice(0, limit);
+
+  if (hits.length === 0) {
+    return `No duplicates above threshold ${threshold.toFixed(2)}.`;
+  }
+
+  // Format output with token cost markers.
+  const lines: string[] = [];
+  lines.push(`Top ${hits.length} match(es) above threshold ${threshold.toFixed(2)}:`);
+
+  for (let i = 0; i < hits.length; i++) {
+    const hit = hits[i];
+    const mem = memRepo.getById(hit.memoryId);
+    if (!mem) continue;
+
+    const titleDisplay = mem.title ? `"${mem.title}"` : "(untitled)";
+    const memType = mem.memory_type ?? "fact";
+    const line = `  ${i + 1}. sim=${hit.similarity.toFixed(3)}  ${hit.memoryId}  ${titleDisplay}  (${memType})`;
+    const tokenCost = estimateTokensV2(line);
+    lines.push(`  [${tokenCost}t] ${i + 1}. sim=${hit.similarity.toFixed(3)}  ${hit.memoryId}  ${titleDisplay}  (${memType})`);
+  }
+
+  return lines.join("\n");
+}

--- a/src/tools/memory-graph.ts
+++ b/src/tools/memory-graph.ts
@@ -1,0 +1,58 @@
+// src/tools/memory-graph.ts
+import type { MemoriesRepo } from "../db/memories.js";
+import type { EdgesRepo, EdgeRow, EdgeType } from "../db/edges.js";
+import { estimateTokensV2 } from "../engine/token-estimator.js";
+
+export interface MemoryGraphParams {
+  id: string;
+  depth?: number;
+  edge_types?: EdgeType[];
+  direction?: "out" | "in" | "both";
+}
+
+export async function handleMemoryGraph(
+  memRepo: MemoriesRepo,
+  edgesRepo: EdgesRepo,
+  params: MemoryGraphParams
+): Promise<string> {
+  const depth = params.depth ?? 2;
+  const direction = params.direction ?? "both";
+
+  const root = memRepo.getById(params.id);
+  if (!root) {
+    return `Memory ${params.id} not found.`;
+  }
+
+  const { edges } = edgesRepo.subgraph(params.id, depth, params.edge_types, direction);
+
+  const header = `Memory: "${root.title}" (${root.memory_type})`;
+
+  if (edges.length === 0) {
+    return header;
+  }
+
+  // Sort edges by edge_type then by the other node id
+  const sorted = [...edges].sort((a, b) => {
+    if (a.edge_type !== b.edge_type) return a.edge_type.localeCompare(b.edge_type);
+    const aOther = a.from_id === params.id ? a.to_id : a.from_id;
+    const bOther = b.from_id === params.id ? b.to_id : b.from_id;
+    return aOther.localeCompare(bOther);
+  });
+
+  const lines: string[] = [header];
+  for (const edge of sorted) {
+    const otherId = edge.from_id === params.id ? edge.to_id : edge.from_id;
+    const isOutgoing = edge.from_id === params.id;
+    const dirMarker = isOutgoing ? `->${edge.edge_type}` : `<-${edge.edge_type}`;
+
+    const otherMem = memRepo.getById(otherId);
+    const otherTitle = otherMem ? otherMem.title : otherId;
+    const otherType = otherMem ? otherMem.memory_type : "unknown";
+
+    const lineContent = `  ${dirMarker} "${otherTitle}" (${otherType})`;
+    const tokenCost = estimateTokensV2(lineContent);
+    lines.push(`${lineContent} [${tokenCost}t]`);
+  }
+
+  return lines.join("\n");
+}

--- a/src/tools/memory-link.ts
+++ b/src/tools/memory-link.ts
@@ -1,0 +1,34 @@
+// src/tools/memory-link.ts
+import type { MemoriesRepo } from "../db/memories.js";
+import type { EdgesRepo } from "../db/edges.js";
+import type { EdgeType } from "../db/edges.js";
+
+export interface MemoryLinkParams {
+  from_id: string;
+  to_id: string;
+  edge_type: EdgeType;
+  weight?: number;
+}
+
+export async function handleMemoryLink(
+  memRepo: MemoriesRepo,
+  edgesRepo: EdgesRepo,
+  params: MemoryLinkParams
+): Promise<string> {
+  const from = memRepo.getById(params.from_id);
+  if (!from) {
+    return `Error: Memory ${params.from_id} not found or has been deleted.`;
+  }
+  const to = memRepo.getById(params.to_id);
+  if (!to) {
+    return `Error: Memory ${params.to_id} not found or has been deleted.`;
+  }
+
+  try {
+    edgesRepo.link(params.from_id, params.to_id, params.edge_type, params.weight ?? 1.0);
+  } catch (err) {
+    return `Error: ${err instanceof Error ? err.message : String(err)}`;
+  }
+
+  return `Linked ${params.from_id} --[${params.edge_type}]--> ${params.to_id}`;
+}

--- a/src/tools/memory-path.ts
+++ b/src/tools/memory-path.ts
@@ -1,0 +1,57 @@
+// src/tools/memory-path.ts
+import type { MemoriesRepo } from "../db/memories.js";
+import type { EdgesRepo, EdgeType } from "../db/edges.js";
+
+export interface MemoryPathParams {
+  from_id: string;
+  to_id: string;
+  max_hops?: number;
+  edge_types?: EdgeType[];
+}
+
+export async function handleMemoryPath(
+  memRepo: MemoriesRepo,
+  edgesRepo: EdgesRepo,
+  params: MemoryPathParams
+): Promise<string> {
+  const maxHops = params.max_hops ?? 4;
+
+  const path = edgesRepo.shortestPath(params.from_id, params.to_id, maxHops, params.edge_types);
+  if (!path) {
+    return `No path from ${params.from_id} to ${params.to_id} within ${maxHops} hops`;
+  }
+
+  if (path.length === 1) {
+    const mem = memRepo.getById(path[0]);
+    const title = mem ? mem.title : path[0];
+    return `${path[0]} "${title}"`;
+  }
+
+  const parts: string[] = [];
+  for (let i = 0; i < path.length; i++) {
+    const nodeId = path[i];
+    const mem = memRepo.getById(nodeId);
+    const title = mem ? mem.title : nodeId;
+    parts.push(`${nodeId} "${title}"`);
+
+    if (i < path.length - 1) {
+      const nextId = path[i + 1];
+      // Find edge type between nodeId and nextId
+      const outEdges = edgesRepo.outgoing(nodeId, params.edge_types);
+      const matchingOut = outEdges.find(e => e.to_id === nextId);
+      if (matchingOut) {
+        parts.push(`→ ${matchingOut.edge_type} →`);
+      } else {
+        const inEdges = edgesRepo.incoming(nodeId, params.edge_types);
+        const matchingIn = inEdges.find(e => e.from_id === nextId);
+        if (matchingIn) {
+          parts.push(`→ ${matchingIn.edge_type} →`);
+        } else {
+          parts.push(`→`);
+        }
+      }
+    }
+  }
+
+  return parts.join(" ");
+}

--- a/src/tools/memory-unlink.ts
+++ b/src/tools/memory-unlink.ts
@@ -1,0 +1,20 @@
+// src/tools/memory-unlink.ts
+import type { EdgesRepo } from "../db/edges.js";
+import type { EdgeType } from "../db/edges.js";
+
+export interface MemoryUnlinkParams {
+  from_id: string;
+  to_id: string;
+  edge_type: EdgeType;
+}
+
+export async function handleMemoryUnlink(
+  edgesRepo: EdgesRepo,
+  params: MemoryUnlinkParams
+): Promise<string> {
+  const removed = edgesRepo.unlink(params.from_id, params.to_id, params.edge_type);
+  if (!removed) {
+    return `No edge found: ${params.from_id} --[${params.edge_type}]--> ${params.to_id}`;
+  }
+  return `Unlinked ${params.from_id} --[${params.edge_type}]--> ${params.to_id}`;
+}

--- a/tests/db/database.test.ts
+++ b/tests/db/database.test.ts
@@ -38,14 +38,14 @@ describe("database", () => {
 
   it("tracks schema version via user_version", () => {
     const version = db.pragma("user_version", { simple: true });
-    expect(version).toBe(7);
+    expect(version).toBe(8);
   });
 
   it("is idempotent — calling createDatabase twice on same path doesn't error", () => {
     db.close();
     const db2 = createDatabase(dbPath);
     const version = db2.pragma("user_version", { simple: true });
-    expect(version).toBe(7);
+    expect(version).toBe(8);
     db2.close();
     db = createDatabase(dbPath); // re-open for afterEach
   });

--- a/tests/db/edges.test.ts
+++ b/tests/db/edges.test.ts
@@ -1,0 +1,205 @@
+// tests/db/edges.test.ts
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { createDatabase } from "../../src/db/database.js";
+import { MemoriesRepo } from "../../src/db/memories.js";
+import { EdgesRepo, ALLOWED_EDGE_TYPES } from "../../src/db/edges.js";
+import { rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomUUID } from "node:crypto";
+
+describe("EdgesRepo", () => {
+  let db: ReturnType<typeof createDatabase>;
+  let memRepo: MemoriesRepo;
+  let edgesRepo: EdgesRepo;
+  const dbPath = join(tmpdir(), `memento-edges-${process.pid}-${randomUUID()}.sqlite`);
+
+  beforeEach(() => {
+    db = createDatabase(dbPath);
+    memRepo = new MemoriesRepo(db);
+    edgesRepo = new EdgesRepo(db);
+  });
+  afterEach(() => {
+    db.close();
+    rmSync(dbPath, { force: true });
+  });
+
+  function storeMemory(title: string): string {
+    return memRepo.store({ title, body: `body of ${title}`, memoryType: "fact", scope: "global" });
+  }
+
+  it("link and unlink happy path", () => {
+    const a = storeMemory("A");
+    const b = storeMemory("B");
+    edgesRepo.link(a, b, "relates_to");
+    const edges = edgesRepo.outgoing(a);
+    expect(edges).toHaveLength(1);
+    expect(edges[0].from_id).toBe(a);
+    expect(edges[0].to_id).toBe(b);
+    expect(edges[0].edge_type).toBe("relates_to");
+    expect(edges[0].weight).toBe(1.0);
+
+    const removed = edgesRepo.unlink(a, b, "relates_to");
+    expect(removed).toBe(true);
+    expect(edgesRepo.outgoing(a)).toHaveLength(0);
+  });
+
+  it("unlink returns false when edge does not exist", () => {
+    const a = storeMemory("A");
+    const b = storeMemory("B");
+    expect(edgesRepo.unlink(a, b, "relates_to")).toBe(false);
+  });
+
+  it("INSERT OR REPLACE updates weight on re-link", () => {
+    const a = storeMemory("A");
+    const b = storeMemory("B");
+    edgesRepo.link(a, b, "relates_to", 0.5);
+    edgesRepo.link(a, b, "relates_to", 0.9);
+    const edges = edgesRepo.outgoing(a);
+    expect(edges).toHaveLength(1);
+    expect(edges[0].weight).toBeCloseTo(0.9);
+  });
+
+  it("rejects self-edges", () => {
+    const a = storeMemory("A");
+    expect(() => edgesRepo.link(a, a, "relates_to")).toThrow("Self-edges are not allowed");
+  });
+
+  it("rejects unknown edge_type", () => {
+    const a = storeMemory("A");
+    const b = storeMemory("B");
+    // @ts-expect-error intentional bad type
+    expect(() => edgesRepo.link(a, b, "bad_type")).toThrow("Unknown edge type");
+  });
+
+  it("outgoing filters by edge types", () => {
+    const a = storeMemory("A");
+    const b = storeMemory("B");
+    const c = storeMemory("C");
+    edgesRepo.link(a, b, "relates_to");
+    edgesRepo.link(a, c, "supersedes");
+
+    const relatesOnly = edgesRepo.outgoing(a, ["relates_to"]);
+    expect(relatesOnly).toHaveLength(1);
+    expect(relatesOnly[0].to_id).toBe(b);
+
+    const both = edgesRepo.outgoing(a);
+    expect(both).toHaveLength(2);
+  });
+
+  it("incoming filters by edge types", () => {
+    const a = storeMemory("A");
+    const b = storeMemory("B");
+    const c = storeMemory("C");
+    edgesRepo.link(b, a, "caused_by");
+    edgesRepo.link(c, a, "references");
+
+    const causedOnly = edgesRepo.incoming(a, ["caused_by"]);
+    expect(causedOnly).toHaveLength(1);
+    expect(causedOnly[0].from_id).toBe(b);
+
+    const all = edgesRepo.incoming(a);
+    expect(all).toHaveLength(2);
+  });
+
+  it("subgraph at depth 0 returns only root with no edges", () => {
+    const a = storeMemory("A");
+    const b = storeMemory("B");
+    edgesRepo.link(a, b, "relates_to");
+
+    const { nodes, edges } = edgesRepo.subgraph(a, 0);
+    expect(nodes).toEqual([a]);
+    expect(edges).toHaveLength(0);
+  });
+
+  it("subgraph at depth 1 returns direct neighbors", () => {
+    const a = storeMemory("A");
+    const b = storeMemory("B");
+    const c = storeMemory("C");
+    edgesRepo.link(a, b, "relates_to");
+    edgesRepo.link(a, c, "supersedes");
+
+    const { nodes, edges } = edgesRepo.subgraph(a, 1);
+    expect(nodes).toContain(a);
+    expect(nodes).toContain(b);
+    expect(nodes).toContain(c);
+    expect(edges).toHaveLength(2);
+  });
+
+  it("subgraph at depth 2 traverses two hops", () => {
+    const a = storeMemory("A");
+    const b = storeMemory("B");
+    const c = storeMemory("C");
+    edgesRepo.link(a, b, "relates_to");
+    edgesRepo.link(b, c, "caused_by");
+
+    // direction='out' so we only follow outgoing edges and avoid double-counting
+    const { nodes, edges } = edgesRepo.subgraph(a, 2, undefined, "out");
+    expect(nodes).toContain(a);
+    expect(nodes).toContain(b);
+    expect(nodes).toContain(c);
+    expect(edges).toHaveLength(2);
+  });
+
+  it("subgraph respects direction=out (no incoming traversal)", () => {
+    const a = storeMemory("A");
+    const b = storeMemory("B");
+    const c = storeMemory("C");
+    edgesRepo.link(a, b, "relates_to");
+    edgesRepo.link(c, a, "references");
+
+    const { nodes } = edgesRepo.subgraph(a, 1, undefined, "out");
+    expect(nodes).toContain(b);
+    expect(nodes).not.toContain(c);
+  });
+
+  it("shortestPath finds shortest path between nodes", () => {
+    const a = storeMemory("A");
+    const b = storeMemory("B");
+    const c = storeMemory("C");
+    edgesRepo.link(a, b, "relates_to");
+    edgesRepo.link(b, c, "caused_by");
+
+    const path = edgesRepo.shortestPath(a, c, 4);
+    expect(path).not.toBeNull();
+    expect(path).toEqual([a, b, c]);
+  });
+
+  it("shortestPath returns null when unreachable", () => {
+    const a = storeMemory("A");
+    const b = storeMemory("B");
+
+    const path = edgesRepo.shortestPath(a, b, 4);
+    expect(path).toBeNull();
+  });
+
+  it("shortestPath returns [id] when from === to", () => {
+    const a = storeMemory("A");
+    const path = edgesRepo.shortestPath(a, a, 4);
+    expect(path).toEqual([a]);
+  });
+
+  it("shortestPath returns null when path exceeds maxHops", () => {
+    const a = storeMemory("A");
+    const b = storeMemory("B");
+    const c = storeMemory("C");
+    edgesRepo.link(a, b, "relates_to");
+    edgesRepo.link(b, c, "relates_to");
+
+    // maxHops=1 cannot reach c (requires 2 hops)
+    const path = edgesRepo.shortestPath(a, c, 1);
+    expect(path).toBeNull();
+  });
+
+  it("cascade-delete: deleting a memory removes its edges", () => {
+    const a = storeMemory("A");
+    const b = storeMemory("B");
+    edgesRepo.link(a, b, "relates_to");
+
+    // Hard-delete memory A to trigger CASCADE
+    db.prepare("DELETE FROM memories WHERE id = ?").run(a);
+
+    const remaining = db.prepare("SELECT * FROM memory_edges WHERE from_id = ? OR to_id = ?").all(a, a);
+    expect(remaining).toHaveLength(0);
+  });
+});

--- a/tests/db/migration-v2.test.ts
+++ b/tests/db/migration-v2.test.ts
@@ -47,10 +47,10 @@ describe("database migration v2", () => {
     expect(col!.dflt_value).toContain("0.5");
   });
 
-  it("sets schema version to 7 (latest migration)", () => {
+  it("sets schema version to 8 (latest migration)", () => {
     db = createDatabase(dbPath);
     const version = db.pragma("user_version", { simple: true });
-    expect(version).toBe(7);
+    expect(version).toBe(8);
   });
 
   it("is idempotent - running createDatabase twice does not error", () => {
@@ -58,7 +58,7 @@ describe("database migration v2", () => {
     db.close();
     db = createDatabase(dbPath);
     const version = db.pragma("user_version", { simple: true });
-    expect(version).toBe(7);
+    expect(version).toBe(8);
   });
 
   it("migrates existing v1 database without data loss", () => {

--- a/tests/integration/migration-v8-edges.test.ts
+++ b/tests/integration/migration-v8-edges.test.ts
@@ -1,0 +1,75 @@
+// tests/integration/migration-v8-edges.test.ts
+// Verify that migration v8 creates memory_edges, and that MemoriesRepo.store()
+// with supersedesId writes both the FK column and a matching edge row.
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { createDatabase } from "../../src/db/database.js";
+import { MemoriesRepo } from "../../src/db/memories.js";
+import { rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomUUID } from "node:crypto";
+
+describe("migration v8: memory_edges", () => {
+  let db: ReturnType<typeof createDatabase>;
+  let memRepo: MemoriesRepo;
+  const dbPath = join(tmpdir(), `memento-v8-${process.pid}-${randomUUID()}.sqlite`);
+
+  beforeEach(() => {
+    db = createDatabase(dbPath);
+    memRepo = new MemoriesRepo(db);
+  });
+  afterEach(() => {
+    db.close();
+    rmSync(dbPath, { force: true });
+  });
+
+  it("PRAGMA user_version is 8 after migrations", () => {
+    const version = db.pragma("user_version", { simple: true }) as number;
+    expect(version).toBe(8);
+  });
+
+  it("memory_edges table exists after migration", () => {
+    const tables = db.prepare(
+      "SELECT name FROM sqlite_master WHERE type='table' AND name='memory_edges'"
+    ).all() as Array<{ name: string }>;
+    expect(tables).toHaveLength(1);
+  });
+
+  it("store() with supersedesId writes both supersedes_memory_id column and edge row", () => {
+    const idA = memRepo.store({
+      title: "Memory A",
+      body: "original",
+      memoryType: "fact",
+      scope: "global",
+    });
+
+    const idB = memRepo.store({
+      title: "Memory B",
+      body: "supersedes A",
+      memoryType: "fact",
+      scope: "global",
+      supersedesId: idA,
+    });
+
+    // Check the column is set
+    const memB = db.prepare("SELECT supersedes_memory_id FROM memories WHERE id = ?").get(idB) as any;
+    expect(memB.supersedes_memory_id).toBe(idA);
+
+    // Check the edge row exists
+    const edge = db.prepare(
+      "SELECT * FROM memory_edges WHERE from_id = ? AND to_id = ? AND edge_type = 'supersedes'"
+    ).get(idB, idA) as any;
+    expect(edge).not.toBeNull();
+    expect(edge.from_id).toBe(idB);
+    expect(edge.to_id).toBe(idA);
+    expect(edge.weight).toBe(1.0);
+  });
+
+  it("backfill: pre-existing memories with supersedes_memory_id get an edge on migration", () => {
+    // The migration backfill runs on an empty DB here, so we just verify the
+    // backfill SQL compiles — no pre-existing supersedes rows in a fresh DB.
+    const edgeCount = db.prepare("SELECT COUNT(*) as c FROM memory_edges").get() as { c: number };
+    // A fresh DB has no supersedes rows, so no edges from backfill.
+    expect(edgeCount.c).toBeGreaterThanOrEqual(0);
+  });
+});

--- a/tests/integration/phase1-token-savings.test.ts
+++ b/tests/integration/phase1-token-savings.test.ts
@@ -41,9 +41,9 @@ describe("Phase 1 integration: token savings validation", () => {
   });
   afterEach(() => { db.close(); rmSync(dbPath, { force: true }); });
 
-  it("database has schema version 7 (v7 migration has landed)", () => {
+  it("database has schema version 8 (v8 migration has landed)", () => {
     const version = db.pragma("user_version", { simple: true });
-    expect(version).toBe(7);
+    expect(version).toBe(8);
   });
 
   it("memories table has source and adaptive_score columns", () => {

--- a/tests/integration/private-roundtrip.test.ts
+++ b/tests/integration/private-roundtrip.test.ts
@@ -139,10 +139,10 @@ describe("migration v5→v6: existing rows backfill", () => {
     rawDb.pragma("user_version = 5");
     rawDb.close();
 
-    // Now open with createDatabase — should apply v6 migration (and v7).
+    // Now open with createDatabase — should apply v6, v7, and v8 migrations.
     db = createDatabase(dbPath);
     const version = db.pragma("user_version", { simple: true });
-    expect(version).toBe(7);
+    expect(version).toBe(8);
 
     // m1 should have has_private=1 (backfilled).
     const m1 = db.prepare("SELECT has_private FROM memories WHERE id = 'm1'").get() as any;

--- a/tests/regression/v1-behavior.test.ts
+++ b/tests/regression/v1-behavior.test.ts
@@ -236,9 +236,9 @@ describe("v1 regression: database schema", () => {
     expect(tables).toContain("decisions_fts");
   });
 
-  it("schema version is 7 for fresh DB (v7 migration applied)", () => {
+  it("schema version is 8 for fresh DB (v8 migration applied)", () => {
     const version = db.pragma("user_version", { simple: true });
-    expect(version).toBe(7);
+    expect(version).toBe(8);
   });
 
   it("FTS sync triggers exist", () => {

--- a/tests/sync/migration-v7.test.ts
+++ b/tests/sync/migration-v7.test.ts
@@ -12,8 +12,8 @@ describe("migration v7: sync_state + sync_file_hashes tables", () => {
   beforeEach(() => { db = createDatabase(dbPath); });
   afterEach(() => { db.close(); rmSync(dbPath, { force: true }); });
 
-  it("sets user_version to 7", () => {
-    expect(db.pragma("user_version", { simple: true })).toBe(7);
+  it("sets user_version to 8 (v8 migration now latest)", () => {
+    expect(db.pragma("user_version", { simple: true })).toBe(8);
   });
 
   it("creates sync_state table with correct columns", () => {
@@ -47,6 +47,6 @@ describe("migration v7: sync_state + sync_file_hashes tables", () => {
   it("is idempotent: re-opening doesn't error", () => {
     db.close();
     db = createDatabase(dbPath);
-    expect(db.pragma("user_version", { simple: true })).toBe(7);
+    expect(db.pragma("user_version", { simple: true })).toBe(8);
   });
 });

--- a/tests/tools/memory-dedup-check.test.ts
+++ b/tests/tools/memory-dedup-check.test.ts
@@ -1,0 +1,363 @@
+// tests/tools/memory-dedup-check.test.ts
+// Tests for the memory_dedup_check tool (issue #28).
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { createDatabase } from "../../src/db/database.js";
+import { MemoriesRepo } from "../../src/db/memories.js";
+import { EmbeddingsRepo } from "../../src/db/embeddings.js";
+import { handleMemoryDedupCheck } from "../../src/tools/memory-dedup-check.js";
+import { DEFAULT_CONFIG } from "../../src/lib/config.js";
+import { rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomUUID } from "node:crypto";
+
+// Normalise vector helper
+function normalise(v: Float32Array): Float32Array {
+  let mag = 0;
+  for (let i = 0; i < v.length; i++) mag += v[i] * v[i];
+  mag = Math.sqrt(mag);
+  return v.map(x => x / mag) as Float32Array;
+}
+
+function makeVec(seed: number, dim = 4): Float32Array {
+  const v = new Float32Array(dim);
+  for (let i = 0; i < dim; i++) v[i] = Math.sin(seed + i * 0.1);
+  return normalise(v);
+}
+
+// Build a config with embeddings enabled and dedup active
+function dedupConfig(overrides: Partial<typeof DEFAULT_CONFIG["search"]["embeddings"]> = {}) {
+  return {
+    ...DEFAULT_CONFIG,
+    search: {
+      ...DEFAULT_CONFIG.search,
+      embeddings: {
+        ...DEFAULT_CONFIG.search.embeddings,
+        enabled: true,
+        dedup: true,
+        dedupThreshold: 0.92,
+        dedupDefaultMode: "warn" as const,
+        dedupCheckOnUpdate: true,
+        dedupMaxScan: 2000,
+        ...overrides,
+      },
+    },
+  };
+}
+
+describe("memory_dedup_check tool", () => {
+  let db: ReturnType<typeof createDatabase>;
+  let memRepo: MemoriesRepo;
+  let embRepo: EmbeddingsRepo;
+  const dbPath = join(tmpdir(), `memento-dedup-check-${process.pid}-${randomUUID()}.sqlite`);
+
+  beforeEach(() => {
+    db = createDatabase(dbPath);
+    memRepo = new MemoriesRepo(db);
+    embRepo = new EmbeddingsRepo(db);
+  });
+
+  afterEach(() => {
+    db.close();
+    rmSync(dbPath, { force: true });
+    vi.restoreAllMocks();
+  });
+
+  it("disabled mode: config.search.embeddings.enabled = false returns no-op message", async () => {
+    const config = { ...DEFAULT_CONFIG }; // embeddings.enabled = false
+    const result = await handleMemoryDedupCheck(
+      db,
+      memRepo,
+      embRepo,
+      null,
+      config,
+      { content: "test" },
+    );
+    expect(result).toBe("Dedup unavailable: embeddings disabled (set search.embeddings.enabled = true and provide API key).");
+  });
+
+  it("no provider: provider = null returns no-op message", async () => {
+    const config = dedupConfig();
+    const result = await handleMemoryDedupCheck(
+      db,
+      memRepo,
+      embRepo,
+      null,
+      config,
+      { content: "test" },
+    );
+    expect(result).toBe("Dedup unavailable: embeddings disabled (set search.embeddings.enabled = true and provide API key).");
+  });
+
+  it("no matches: provider returns vector that doesn't match seeded memories", async () => {
+    const createProviderMod = await import("../../src/engine/embeddings/provider.js");
+    vi.spyOn(createProviderMod, "createProvider").mockReturnValue({
+      model: "test-model",
+      dim: 4,
+      embed: vi.fn().mockResolvedValue([makeVec(999)]), // Very different seed
+    });
+
+    // Seed a memory with a different vector
+    const id1 = memRepo.store({
+      title: "Different topic",
+      body: "This is about something completely different",
+      memoryType: "fact",
+      scope: "global",
+    });
+    embRepo.upsert(id1, "test-model", makeVec(42));
+
+    const config = dedupConfig({ dedupThreshold: 0.92 });
+    const provider = createProviderMod.createProvider(config.search.embeddings);
+    const result = await handleMemoryDedupCheck(
+      db,
+      memRepo,
+      embRepo,
+      provider,
+      config,
+      { content: "test content" },
+    );
+    expect(result).toContain("No duplicates above threshold");
+  });
+
+  it("matches found: returns formatted top-N list with token markers and memory details", async () => {
+    // Seed 3 memories
+    const id1 = memRepo.store({
+      title: "Postgres DB",
+      body: "Use postgres for databases",
+      memoryType: "fact",
+      scope: "global",
+    });
+    const id2 = memRepo.store({
+      title: "MySQL alternative",
+      body: "MySQL is also a database",
+      memoryType: "fact",
+      scope: "global",
+    });
+    const id3 = memRepo.store({
+      title: "SQLite option",
+      body: "SQLite for embedded databases",
+      memoryType: "fact",
+      scope: "global",
+    });
+
+    // Use same vector for all to ensure high similarity
+    const baseVec = makeVec(42);
+    embRepo.upsert(id1, "test-model", baseVec);
+    embRepo.upsert(id2, "test-model", baseVec);
+    embRepo.upsert(id3, "test-model", baseVec);
+
+    const createProviderMod = await import("../../src/engine/embeddings/provider.js");
+    vi.spyOn(createProviderMod, "createProvider").mockReturnValue({
+      model: "test-model",
+      dim: 4,
+      embed: vi.fn().mockResolvedValue([new Float32Array(baseVec)]),
+    });
+
+    const config = dedupConfig();
+    const provider = createProviderMod.createProvider(config.search.embeddings, console as any);
+    const result = await handleMemoryDedupCheck(
+      db,
+      memRepo,
+      embRepo,
+      provider,
+      config,
+      { content: "database topic" },
+    );
+
+    // Should start with "Top"
+    expect(result).toMatch(/^Top \d+ match\(es\)/);
+    // Should contain token markers
+    expect(result).toMatch(/\[\d+t\]/);
+    // Should contain similarity scores
+    expect(result).toContain("sim=");
+    // Should contain at least one memory title
+    expect(result).toMatch(/Postgres DB|MySQL alternative|SQLite option/);
+    // Should contain memory type
+    expect(result).toContain("(fact)");
+  });
+
+  it("threshold override: strict threshold filters results", async () => {
+    const id1 = memRepo.store({
+      title: "Test memory",
+      body: "test content",
+      memoryType: "fact",
+      scope: "global",
+    });
+    embRepo.upsert(id1, "test-model", makeVec(42));
+
+    const createProviderMod = await import("../../src/engine/embeddings/provider.js");
+    vi.spyOn(createProviderMod, "createProvider").mockReturnValue({
+      model: "test-model",
+      dim: 4,
+      // Use a very different seed to create low similarity (~0.69)
+      embed: vi.fn().mockResolvedValue([new Float32Array(makeVec(50))]),
+    });
+
+    const config = dedupConfig();
+    const provider = createProviderMod.createProvider(config.search.embeddings, console as any);
+
+    // With very strict threshold (0.99), should find no matches (similarity ~0.69 << 0.99)
+    const result = await handleMemoryDedupCheck(
+      db,
+      memRepo,
+      embRepo,
+      provider,
+      config,
+      { content: "test", threshold: 0.99 },
+    );
+    expect(result).toContain("No duplicates above threshold 0.99");
+  });
+
+  it("threshold override: loose threshold shows more matches", async () => {
+    const id1 = memRepo.store({
+      title: "Test memory",
+      body: "test content",
+      memoryType: "fact",
+      scope: "global",
+    });
+    embRepo.upsert(id1, "test-model", makeVec(42));
+
+    const createProviderMod = await import("../../src/engine/embeddings/provider.js");
+    vi.spyOn(createProviderMod, "createProvider").mockReturnValue({
+      model: "test-model",
+      dim: 4,
+      embed: vi.fn().mockResolvedValue([new Float32Array(makeVec(42))]),
+    });
+
+    const config = dedupConfig();
+    const provider = createProviderMod.createProvider(config.search.embeddings, console as any);
+
+    // With very loose threshold (0.0), should find matches
+    const result = await handleMemoryDedupCheck(
+      db,
+      memRepo,
+      embRepo,
+      provider,
+      config,
+      { content: "test", threshold: 0.0 },
+    );
+    expect(result).toMatch(/^Top \d+ match/);
+    expect(result).toContain("Test memory");
+  });
+
+  it("limit cap: limit=50 never returns more than 20 results", async () => {
+    // Seed 25 memories
+    for (let i = 0; i < 25; i++) {
+      const id = memRepo.store({
+        title: `Memory ${i}`,
+        body: `Content for memory ${i}`,
+        memoryType: "fact",
+        scope: "global",
+      });
+      embRepo.upsert(id, "test-model", makeVec(42));
+    }
+
+    const createProviderMod = await import("../../src/engine/embeddings/provider.js");
+    vi.spyOn(createProviderMod, "createProvider").mockReturnValue({
+      model: "test-model",
+      dim: 4,
+      embed: vi.fn().mockResolvedValue([new Float32Array(makeVec(42))]),
+    });
+
+    const config = dedupConfig();
+    const provider = createProviderMod.createProvider(config.search.embeddings, console as any);
+
+    const result = await handleMemoryDedupCheck(
+      db,
+      memRepo,
+      embRepo,
+      provider,
+      config,
+      { content: "test", limit: 50 },
+    );
+
+    // Count lines starting with [Nt]
+    const lines = result.split("\n");
+    const resultLines = lines.filter((l) => l.match(/\[\d+t\]/));
+    expect(resultLines.length).toBeLessThanOrEqual(20);
+  });
+
+  it("project scoping: only returns matches in the specified project", async () => {
+    // Create two projects
+    const projectA = memRepo.ensureProject("/test/project-a");
+    const projectB = memRepo.ensureProject("/test/project-b");
+
+    // Seed memories in project A
+    const idA = memRepo.store({
+      title: "Memory in A",
+      body: "Project A content",
+      memoryType: "fact",
+      scope: "project",
+      projectId: projectA,
+    });
+
+    // Seed memories in project B
+    const idB = memRepo.store({
+      title: "Memory in B",
+      body: "Project B content",
+      memoryType: "fact",
+      scope: "project",
+      projectId: projectB,
+    });
+
+    const baseVec = makeVec(42);
+    embRepo.upsert(idA, "test-model", baseVec);
+    embRepo.upsert(idB, "test-model", baseVec);
+
+    const createProviderMod = await import("../../src/engine/embeddings/provider.js");
+    vi.spyOn(createProviderMod, "createProvider").mockReturnValue({
+      model: "test-model",
+      dim: 4,
+      embed: vi.fn().mockResolvedValue([new Float32Array(baseVec)]),
+    });
+
+    const config = dedupConfig();
+    const provider = createProviderMod.createProvider(config.search.embeddings, console as any);
+
+    // Call with project_path pointing to project A
+    const result = await handleMemoryDedupCheck(
+      db,
+      memRepo,
+      embRepo,
+      provider,
+      config,
+      { content: "test", project_path: "/test/project-a" },
+    );
+
+    // Should contain memory from A
+    expect(result).toContain("Memory in A");
+    // Should NOT contain memory from B
+    expect(result).not.toContain("Memory in B");
+  });
+
+  it("title concatenation: includes title in text when provided", async () => {
+    const createProviderMod = await import("../../src/engine/embeddings/provider.js");
+    let lastEmbedInput: string[] = [];
+    vi.spyOn(createProviderMod, "createProvider").mockReturnValue({
+      model: "test-model",
+      dim: 4,
+      embed: vi.fn().mockImplementation((texts: string[]) => {
+        lastEmbedInput = texts;
+        return [makeVec(42)];
+      }),
+    });
+
+    const config = dedupConfig();
+    const provider = createProviderMod.createProvider(config.search.embeddings, console as any);
+
+    await handleMemoryDedupCheck(
+      db,
+      memRepo,
+      embRepo,
+      provider,
+      config,
+      { content: "body text", title: "Test Title" },
+    );
+
+    // The concatenated text should include both title and body
+    // (with scrubSecrets/redactPrivate applied, but structure preserved)
+    expect(lastEmbedInput[0]).toContain("Test Title");
+    expect(lastEmbedInput[0]).toContain("body text");
+  });
+});

--- a/tests/tools/memory-graph.test.ts
+++ b/tests/tools/memory-graph.test.ts
@@ -1,0 +1,74 @@
+// tests/tools/memory-graph.test.ts
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { createDatabase } from "../../src/db/database.js";
+import { MemoriesRepo } from "../../src/db/memories.js";
+import { EdgesRepo } from "../../src/db/edges.js";
+import { handleMemoryGraph } from "../../src/tools/memory-graph.js";
+import { rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomUUID } from "node:crypto";
+
+describe("handleMemoryGraph", () => {
+  let db: ReturnType<typeof createDatabase>;
+  let memRepo: MemoriesRepo;
+  let edgesRepo: EdgesRepo;
+  const dbPath = join(tmpdir(), `memento-graph-${process.pid}-${randomUUID()}.sqlite`);
+
+  beforeEach(() => {
+    db = createDatabase(dbPath);
+    memRepo = new MemoriesRepo(db);
+    edgesRepo = new EdgesRepo(db);
+  });
+  afterEach(() => {
+    db.close();
+    rmSync(dbPath, { force: true });
+  });
+
+  function storeMemory(title: string): string {
+    return memRepo.store({ title, body: `body of ${title}`, memoryType: "fact", scope: "global" });
+  }
+
+  it("output starts with Memory: and title in quotes", async () => {
+    const a = storeMemory("Root Memory");
+    const result = await handleMemoryGraph(memRepo, edgesRepo, { id: a });
+    expect(result).toMatch(/^Memory: "Root Memory"/);
+  });
+
+  it("output contains [Nt] token markers for neighbor lines", async () => {
+    const a = storeMemory("Root");
+    const b = storeMemory("Neighbor");
+    edgesRepo.link(a, b, "relates_to");
+
+    const result = await handleMemoryGraph(memRepo, edgesRepo, { id: a });
+    expect(result).toContain("[");
+    expect(result).toMatch(/\[\d+t\]/);
+  });
+
+  it("depth=0 emits zero neighbor lines (only root header)", async () => {
+    const a = storeMemory("Root");
+    const b = storeMemory("Neighbor");
+    edgesRepo.link(a, b, "relates_to");
+
+    const result = await handleMemoryGraph(memRepo, edgesRepo, { id: a, depth: 0 });
+    const lines = result.split("\n").filter(l => l.trim().length > 0);
+    // Only the header line should be present
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toMatch(/^Memory:/);
+  });
+
+  it("returns not found for unknown memory id", async () => {
+    const result = await handleMemoryGraph(memRepo, edgesRepo, { id: "no-such-id" });
+    expect(result).toContain("not found");
+  });
+
+  it("includes edge direction markers in output", async () => {
+    const a = storeMemory("Root");
+    const b = storeMemory("Child");
+    edgesRepo.link(a, b, "implements");
+
+    const result = await handleMemoryGraph(memRepo, edgesRepo, { id: a });
+    // Should contain direction + edge_type marker
+    expect(result).toContain("implements");
+  });
+});

--- a/tests/tools/memory-link.test.ts
+++ b/tests/tools/memory-link.test.ts
@@ -1,0 +1,80 @@
+// tests/tools/memory-link.test.ts
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { createDatabase } from "../../src/db/database.js";
+import { MemoriesRepo } from "../../src/db/memories.js";
+import { EdgesRepo } from "../../src/db/edges.js";
+import { handleMemoryLink } from "../../src/tools/memory-link.js";
+import { rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomUUID } from "node:crypto";
+
+describe("handleMemoryLink", () => {
+  let db: ReturnType<typeof createDatabase>;
+  let memRepo: MemoriesRepo;
+  let edgesRepo: EdgesRepo;
+  const dbPath = join(tmpdir(), `memento-link-${process.pid}-${randomUUID()}.sqlite`);
+
+  beforeEach(() => {
+    db = createDatabase(dbPath);
+    memRepo = new MemoriesRepo(db);
+    edgesRepo = new EdgesRepo(db);
+  });
+  afterEach(() => {
+    db.close();
+    rmSync(dbPath, { force: true });
+  });
+
+  function storeMemory(title: string): string {
+    return memRepo.store({ title, body: `body of ${title}`, memoryType: "fact", scope: "global" });
+  }
+
+  it("rejects unknown from_id", async () => {
+    const b = storeMemory("B");
+    const result = await handleMemoryLink(memRepo, edgesRepo, {
+      from_id: "nonexistent-id",
+      to_id: b,
+      edge_type: "relates_to",
+    });
+    expect(result).toMatch(/Error/);
+    expect(result).toContain("nonexistent-id");
+  });
+
+  it("rejects unknown to_id", async () => {
+    const a = storeMemory("A");
+    const result = await handleMemoryLink(memRepo, edgesRepo, {
+      from_id: a,
+      to_id: "nonexistent-id",
+      edge_type: "relates_to",
+    });
+    expect(result).toMatch(/Error/);
+    expect(result).toContain("nonexistent-id");
+  });
+
+  it("rejects soft-deleted memory", async () => {
+    const a = storeMemory("A");
+    const b = storeMemory("B");
+    memRepo.delete(b);
+
+    const result = await handleMemoryLink(memRepo, edgesRepo, {
+      from_id: a,
+      to_id: b,
+      edge_type: "relates_to",
+    });
+    expect(result).toMatch(/Error/);
+  });
+
+  it("returns success string on happy path", async () => {
+    const a = storeMemory("A");
+    const b = storeMemory("B");
+    const result = await handleMemoryLink(memRepo, edgesRepo, {
+      from_id: a,
+      to_id: b,
+      edge_type: "relates_to",
+    });
+    expect(result).toContain("Linked");
+    expect(result).toContain(a);
+    expect(result).toContain(b);
+    expect(result).toContain("relates_to");
+  });
+});


### PR DESCRIPTION
Add memory_edges table (migration v8) with 6 edge types, EdgesRepo with BFS subgraph/shortestPath, and 4 MCP tools: memory_link, memory_unlink, memory_graph, memory_path. Supersedes edges written atomically in MemoriesRepo.store(). Update schema-version assertions in existing tests from 7 → 8.

https://claude.ai/code/session_01QCs7QAViNApLH7m2UdNEEc