### PR TITLE
fix(docs): correct npm package scope to @luispmonteiro

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ It stores structured memories locally in SQLite, retrieves the right context whe
 ## Quick start
 
 ```bash
-npm install -g @lfrmonteiro99/memento-memory-mcp
+npm install -g @luispmonteiro/memento-memory-mcp
 memento-mcp install
 memento-mcp import auto       # detects CLAUDE.md, AGENTS.md, .cursor/rules, .github/copilot-instructions, …
 memento-mcp ui
@@ -254,7 +254,7 @@ Browse memories, sessions, projects, sync state, analytics, and drift without op
 **1.** Install from npm:
 
 ```bash
-npm install -g @lfrmonteiro99/memento-memory-mcp
+npm install -g @luispmonteiro/memento-memory-mcp
 ```
 
 **2.** Wire it into your MCP client:
@@ -283,7 +283,7 @@ memento-mcp ui
 
 ```bash
 # 1. Install from npm
-npm install -g @lfrmonteiro99/memento-memory-mcp
+npm install -g @luispmonteiro/memento-memory-mcp
 
 # 2. Wire your MCP client
 memento-mcp install

--- a/docs/development.md
+++ b/docs/development.md
@@ -30,7 +30,7 @@ memento-mcp is designed to keep injected context small without losing relevance:
 
 The v2 upgrade is designed to be drop-in:
 
-1. `npm install -g @lfrmonteiro99/memento-memory-mcp@latest` — the bin names from v1 (`memento-mcp`, `memento-hook-search`, `memento-hook-session`) continue to work. v2 added `memento-hook-capture` and `memento-hook-summarize`.
+1. `npm install -g @luispmonteiro/memento-memory-mcp@latest` — the bin names from v1 (`memento-mcp`, `memento-hook-search`, `memento-hook-session`) continue to work. v2 added `memento-hook-capture` and `memento-hook-summarize`.
 2. The SQLite migration runs automatically on the first open. New tables: `analytics_events`, `compression_log`, `embeddings`, `memory_edges`-equivalents (none yet — see roadmap), `vault_*`, `sync_state`, `sync_file_hashes`. New columns on `memories`: `source`, `adaptive_score`, `claude_session_id`, `has_private`. v1 tags stored as CSV are auto-converted to JSON arrays.
 3. v1 config files continue to parse. New v2 sections (`[auto_capture]`, `[compression]`, `[adaptive]`, `[analytics]`, `[file_memory]`, `[decay]`, `[search.embeddings]`, `[hooks.session_end_llm]`, `[sync]`, `[profile]`) are optional and default to safe values.
 4. Add the `PostToolUse` hook if you want auto-capture (see [install](install.md)). This is what feeds `analytics_events` — skip it and `memory_analytics` will still work but show neutral utility scores.

--- a/docs/install.md
+++ b/docs/install.md
@@ -21,7 +21,7 @@ The package is published on **GitHub Packages**, not the public npm registry.
 ### 1. Configure npm for GitHub Packages
 
 ```bash
-npm config set @lfrmonteiro99:registry https://npm.pkg.github.com
+npm config set @luispmonteiro:registry https://npm.pkg.github.com
 echo "//npm.pkg.github.com/:_authToken=YOUR_PAT_HERE" >> ~/.npmrc
 ```
 
@@ -30,7 +30,7 @@ Replace `YOUR_PAT_HERE` with a GitHub PAT that has `read:packages`.
 ### 2. Install globally
 
 ```bash
-npm install -g @lfrmonteiro99/memento-memory-mcp
+npm install -g @luispmonteiro/memento-memory-mcp
 ```
 
 Global install matters because:
@@ -126,7 +126,7 @@ If `memento-mcp` is not on `PATH`, use an absolute command instead:
 ```toml
 [mcp_servers.memento-mcp]
 command = "/home/you/.nvm/versions/node/v20.20.2/bin/node"
-args = ["/home/you/.nvm/versions/node/v20.20.2/lib/node_modules/@lfrmonteiro99/memento-memory-mcp/dist/cli/main.js"]
+args = ["/home/you/.nvm/versions/node/v20.20.2/lib/node_modules/@luispmonteiro/memento-memory-mcp/dist/cli/main.js"]
 ```
 
 Hooks (Codex 0.114.0, March 2026, or newer). First enable the experimental engine in `~/.codex/config.toml`:

--- a/site/src/components/Install.astro
+++ b/site/src/components/Install.astro
@@ -1,7 +1,7 @@
 ---
 const steps = [
   { title: 'Install',
-    code: 'npm install -g @lfrmonteiro99/memento-memory-mcp' },
+    code: 'npm install -g @luispmonteiro/memento-memory-mcp' },
   { title: 'Wire your MCP client',
     code: 'memento-mcp install',
     note: 'Configures Claude Code, Codex, Cursor, or any other stdio-MCP client.' },

--- a/site/src/components/Terminal.astro
+++ b/site/src/components/Terminal.astro
@@ -1,5 +1,5 @@
 ---
-const copyText = `npm install -g @lfrmonteiro99/memento-memory-mcp
+const copyText = `npm install -g @luispmonteiro/memento-memory-mcp
 memento-mcp install
 memento-mcp import auto
 memento-mcp ui`;
@@ -15,7 +15,7 @@ memento-mcp ui`;
       <span class="t-copy-label">copy</span>
     </button>
   </div>
-  <pre class="terminal-body"><code><span class="prompt">$</span> <span class="cmd">npm install -g</span> <span class="arg">@lfrmonteiro99/memento-memory-mcp</span>
+  <pre class="terminal-body"><code><span class="prompt">$</span> <span class="cmd">npm install -g</span> <span class="arg">@luispmonteiro/memento-memory-mcp</span>
 <span class="prompt">$</span> <span class="cmd">memento-mcp</span> install
 <span class="prompt">$</span> <span class="cmd">memento-mcp</span> import auto  <span class="comment"># CLAUDE.md, AGENTS.md, Cursor, Copilot, …</span>
 <span class="prompt">$</span> <span class="cmd">memento-mcp</span> ui            <span class="comment"># open the local inspector</span>


### PR DESCRIPTION
The published package is @luispmonteiro/memento-memory-mcp, but the
website, docs, and README referenced the @lfrmonteiro99 scope. This
caused install instructions on the GitHub Pages site to fail.

GitHub repo URLs (github.com/lfrmonteiro99/memento-mcp) are unchanged
since the repo itself lives under that account.

https://claude.ai/code/session_01AkorpVMzcTDXj4Lwko5YNo