### PR TITLE
chore(release): v2.1.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@luispmonteiro/memento-memory-mcp",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@luispmonteiro/memento-memory-mcp",
-      "version": "2.1.5",
+      "version": "2.1.6",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luispmonteiro/memento-memory-mcp",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "description": "Persistent memory MCP server with typed memories, decay scoring, and token-aware context injection",
   "type": "module",
   "engines": {


### PR DESCRIPTION
Automated version bump for v2.1.6. Already published to npm and tagged.