### PR TITLE
fix(deps): declare zod as a direct dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",
         "better-sqlite3": "^11.0.0",
-        "smol-toml": "^1.0.0"
+        "smol-toml": "^1.0.0",
+        "zod": "^3.25.28 || ^4.0.0"
       },
       "bin": {
         "memento-hook-capture": "dist/hooks/auto-capture-bin.js",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
     "better-sqlite3": "^11.0.0",
-    "smol-toml": "^1.0.0"
+    "smol-toml": "^1.0.0",
+    "zod": "^3.25.28 || ^4.0.0"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.0.0",


### PR DESCRIPTION
src/index.ts imports zod directly, but it was only resolved
transitively via @modelcontextprotocol/sdk. This works under npm's
hoisting but breaks under pnpm's strict isolation, causing builds to
fail with "Could not resolve 'zod'".