### PR TITLE
fix(deps): bump better-sqlite3 to ^12.0.0 for Node 24 prebuilds

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [18, 20, 22]
+        node: [20, 22, 24]
 
     steps:
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A local-first MCP server that gives **Claude Code**, **Codex**, **Cursor**, and 
 [![npm version](https://img.shields.io/npm/v/@luispmonteiro/memento-memory-mcp.svg?style=flat-square&color=cb3837&logo=npm&logoColor=white&label=npm)](https://www.npmjs.com/package/@luispmonteiro/memento-memory-mcp)
 [![Tests](https://img.shields.io/github/actions/workflow/status/lfrmonteiro99/memento-mcp/tests.yml?branch=master&style=flat-square&logo=github&label=tests)](https://github.com/lfrmonteiro99/memento-mcp/actions/workflows/tests.yml)
 [![Coverage](https://img.shields.io/badge/coverage-91%25-brightgreen?style=flat-square&logo=vitest&logoColor=white)](#testing)
-[![Node.js](https://img.shields.io/badge/node-%3E%3D18-339933?style=flat-square&logo=node.js&logoColor=white)](https://nodejs.org/)
+[![Node.js](https://img.shields.io/badge/node-%3E%3D20-339933?style=flat-square&logo=node.js&logoColor=white)](https://nodejs.org/)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square)](LICENSE)
 [![MCP](https://img.shields.io/badge/MCP-compatible-7c3aed?style=flat-square)](https://modelcontextprotocol.io)
 [![Local-first](https://img.shields.io/badge/local--first-SQLite-003B57?style=flat-square&logo=sqlite&logoColor=white)](#stay-local-by-default)
@@ -104,7 +104,7 @@ memento-mcp ui
 
 ## Requirements
 
-- **Node.js 18** or newer
+- **Node.js 20** or newer (20.x, 22.x, 24.x — Node 18 is EOL and no longer supported)
 - **npm**
 - An **MCP-compatible client**, such as Claude Code, Codex, Cursor, or another stdio-MCP client
 
@@ -542,7 +542,7 @@ Search and hooks can combine both layers.
 
 ## Testing
 
-`memento-mcp` ships with **1,352 tests across 121 test files**, covering **91% of lines and 85% of branches**. The suite runs on Node 18, 20, and 22 in CI on every push and pull request.
+`memento-mcp` ships with **1,352 tests across 121 test files**, covering **91% of lines and 85% of branches**. The suite runs on Node 20, 22, and 24 in CI on every push and pull request.
 
 ### Run the tests
 

--- a/docs/2026-04-16-memento-mcp-plan.md
+++ b/docs/2026-04-16-memento-mcp-plan.md
@@ -6,7 +6,7 @@
 
 **Architecture:** MCP server over stdio using @modelcontextprotocol/sdk. SQLite via better-sqlite3 with FTS5 full-text search. Hooks as standalone bin entry points. Config via TOML with env override.
 
-**Tech Stack:** TypeScript, Node.js >=18, better-sqlite3, smol-toml, vitest, tsup
+**Tech Stack:** TypeScript, Node.js >=20, better-sqlite3, smol-toml, vitest, tsup
 
 **Spec:** `docs/2026-04-16-memento-mcp-design.md`
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -2,14 +2,14 @@
 
 ## Prerequisites
 
-- **Node.js** `>=18`
+- **Node.js** `>=20` (20.x, 22.x, or 24.x — Node 18 is EOL and no longer supported by `better-sqlite3` v12)
 - **npm**
 - a **GitHub Personal Access Token** with `read:packages` to install from GitHub Packages
 - a supported MCP client such as **Codex**, **Claude Code**, **Cursor**, or another stdio-compatible MCP client
 
 Recommended:
 
-- **Node 20** for development and test runs
+- **Node 22** (current LTS) for development and test runs
 - an **Obsidian vault** if you want vault integration (see [Vault integration](vault.md))
 
 If `better-sqlite3` needs compilation on your machine, install the usual native build prerequisites for Node addons.

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",
-        "better-sqlite3": "^11.0.0",
+        "better-sqlite3": "^12.0.0",
         "smol-toml": "^1.0.0",
         "zod": "^3.25.28 || ^4.0.0"
       },
@@ -32,7 +32,7 @@
         "vitest": "^2.0.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1348,14 +1348,17 @@
       "license": "MIT"
     },
     "node_modules/better-sqlite3": {
-      "version": "11.10.0",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-11.10.0.tgz",
-      "integrity": "sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==",
+      "version": "12.9.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.9.0.tgz",
+      "integrity": "sha512-wqUv4Gm3toFpHDQmaKD4QhZm3g1DjUBI0yzS4UBl6lElUmXFYdTQmmEDpAFa5o8FiFiymURypEnfVHzILKaxqQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "bindings": "^1.5.0",
         "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x"
       }
     },
     "node_modules/bindings": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Persistent memory MCP server with typed memories, decay scoring, and token-aware context injection",
   "type": "module",
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "license": "MIT",
   "author": "Luis Monteiro",
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
-    "better-sqlite3": "^11.0.0",
+    "better-sqlite3": "^12.0.0",
     "smol-toml": "^1.0.0",
     "zod": "^3.25.28 || ^4.0.0"
   },


### PR DESCRIPTION
better-sqlite3 v11.10.0 ships prebuilt bindings only through Node 23
(NODE_MODULE_VERSION 131). On Node 24 (NODE_MODULE_VERSION 137) the
loader falls through every candidate path and fails with "Could not
locate the bindings file", crashing the MCP proxy on startup.

v12 adds Node 24/25 prebuilds for all linux/linuxmusl/darwin/win32
targets. The public API used by this codebase is unchanged, so the
upgrade is a drop-in. v12 also drops EOL Node 18, so engines.node is
bumped to >=20 to match.