### PR TITLE
Upgrade MCP tool definitions to TDQS v2 with structured outputs

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": ["lfrmonteiro99"]
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,10 +11,10 @@ import { EdgesRepo } from "./db/edges.js";
 import { loadConfig, getDefaultConfigPath, getDefaultDbPath } from "./lib/config.js";
 import { createLogger, logLevelFromEnv } from "./lib/logger.js";
 import { handleMemoryStore } from "./tools/memory-store.js";
-import { handleMemorySearch } from "./tools/memory-search.js";
+import { searchMemories } from "./tools/memory-search.js";
 import { handleMemoryGet } from "./tools/memory-get.js";
 import { handleMemoryTimeline } from "./tools/memory-timeline.js";
-import { handleMemoryList } from "./tools/memory-list.js";
+import { listMemories } from "./tools/memory-list.js";
 import { handleMemoryDelete } from "./tools/memory-delete.js";
 import { handleMemoryDedupCheck } from "./tools/memory-dedup-check.js";
 import { handleDecisionsLog } from "./tools/decisions-log.js";
@@ -26,8 +26,8 @@ import { handleMemoryPin } from "./tools/memory-pin.js";
 import { handleMemoryExport, handleMemoryImport } from "./tools/memory-transfer.js";
 import { handleMemoryLink } from "./tools/memory-link.js";
 import { handleMemoryUnlink } from "./tools/memory-unlink.js";
-import { handleMemoryGraph } from "./tools/memory-graph.js";
-import { handleMemoryPath } from "./tools/memory-path.js";
+import { walkMemoryGraph } from "./tools/memory-graph.js";
+import { findMemoryPath } from "./tools/memory-path.js";
 import { AnalyticsTracker, installFlushOnExit } from "./analytics/tracker.js";
 import { cleanupExpiredAnalytics } from "./analytics/retention.js";
 import { runCompressionCycle } from "./engine/compressor.js";
@@ -250,10 +250,28 @@ server.registerTool(
       openWorldHint: false,
     },
     outputSchema: {
-      message: z.string().describe("Markdown-formatted ranked results at the requested `detail` level. Empty result set is rendered as `No results found.` Vault hits, when present, are appended in a separate section."),
+      query: z.string().describe("Echo of the query that was executed."),
+      detail: z.enum(["index", "summary", "full"]).describe("Disclosure level used to render this result set."),
+      count: z.number().int().nonnegative().describe("Number of SQLite/file results returned (after `limit` is applied)."),
+      results: z.array(z.object({
+        id: z.string().describe("Memory id, e.g. `mem_01HXYZ...`."),
+        title: z.string().describe("Memory title."),
+        score: z.number().describe("Decay-weighted relevance score in [0, 1] (higher = more relevant)."),
+        source: z.enum(["sqlite", "file"]).describe("Whether the hit came from SQLite or a registered markdown file source."),
+        memory_type: z.string().optional().describe("Memory type when known (e.g. `fact`, `decision`)."),
+        body: z.string().optional().describe("Body preview — only present when `detail=\"summary\"` or `\"full\"`."),
+      })).describe("Ranked SQLite/file hits."),
+      vault_results: z.array(z.object({
+        relativePath: z.string().describe("Path of the vault note relative to the vault root."),
+        title: z.string().optional().describe("Vault note title, when available."),
+      })).describe("Obsidian vault matches (separate from SQLite results). Always an array — empty when the vault is disabled or has no matches."),
+      total_tokens: z.number().int().nonnegative().describe("Estimated token cost of the rendered text payload."),
     },
   },
-  async (params) => textResult(await handleMemorySearch(memRepo, config, params, db, analyticsTracker))
+  async (params) => {
+    const { text, structured } = await searchMemories(memRepo, config, params, db, analyticsTracker);
+    return { content: [{ type: "text" as const, text }], structuredContent: structured };
+  }
 );
 
 server.registerTool(
@@ -368,10 +386,29 @@ server.registerTool(
       openWorldHint: false,
     },
     outputSchema: {
-      message: z.string().describe("Markdown-formatted list at the requested `detail` level, or `No memories found.` Vault notes appear in a separate section when included."),
+      detail: z.enum(["index", "summary", "full"]).describe("Disclosure level used to render this list."),
+      count: z.number().int().nonnegative().describe("Number of SQLite/file memories returned."),
+      memories: z.array(z.object({
+        id: z.string().describe("Memory id."),
+        title: z.string().describe("Memory title."),
+        source: z.enum(["sqlite", "file"]).describe("Whether the row came from SQLite or a registered markdown file source."),
+        memory_type: z.string().optional().describe("Memory type (e.g. `fact`, `decision`)."),
+        importance: z.number().optional().describe("Importance score in [0, 1] when known."),
+        pinned: z.boolean().optional().describe("Pinned flag when known."),
+        body: z.string().optional().describe("Body preview — only present when `detail=\"summary\"` or `\"full\"`."),
+      })).describe("Listed memories ordered by recency/importance."),
+      vault_results: z.array(z.object({
+        id: z.string().describe("Vault note id."),
+        title: z.string().describe("Vault note title."),
+        relativePath: z.string().describe("Path relative to the vault root."),
+        kind: z.string().optional().describe("Vault subtype (e.g. `architecture`, `runbook`) when classified."),
+      })).describe("Obsidian vault matches when the vault is enabled and `vault_kind`/`vault_folder` filters apply. Empty otherwise."),
     },
   },
-  async (params) => textResult(await handleMemoryList(memRepo, config, params, db))
+  async (params) => {
+    const { text, structured } = await listMemories(memRepo, config, params, db);
+    return { content: [{ type: "text" as const, text }], structuredContent: structured };
+  }
 );
 
 server.registerTool(
@@ -713,10 +750,29 @@ server.registerTool(
       openWorldHint: false,
     },
     outputSchema: {
-      message: z.string().describe("Markdown rendering of the BFS frontier: root node + per-hop neighbours grouped by depth, each line showing edge type and target title. Returns `Memory <id> not found.` for a missing root."),
+      found: z.boolean().describe("`true` when the root memory exists. `false` when the id was not found (in which case `root` and `edges` are absent/empty)."),
+      root: z.object({
+        id: z.string().describe("Root memory id."),
+        title: z.string().describe("Root memory title."),
+        memory_type: z.string().describe("Root memory type."),
+      }).optional().describe("Root node metadata; absent when `found=false`."),
+      edges: z.array(z.object({
+        direction: z.enum(["out", "in"]).describe("`out` when the edge points away from the root, `in` when it points toward it."),
+        edge_type: edgeTypeEnum.describe("Typed relationship along this edge."),
+        weight: z.number().optional().describe("Edge strength in [0, 1] when stored."),
+        other: z.object({
+          id: z.string().describe("Far-end memory id."),
+          title: z.string().describe("Far-end memory title (or the id when the memory was deleted)."),
+          memory_type: z.string().describe("Far-end memory type, or `unknown` if the row is missing."),
+        }).describe("The neighbour node on the other side of this edge."),
+        token_cost: z.number().int().nonnegative().describe("Estimated token cost of rendering this edge in the text output."),
+      })).describe("Edges discovered by the BFS walk, sorted by edge_type then by neighbour id."),
     },
   },
-  async (params) => textResult(await handleMemoryGraph(memRepo, edgesRepo, params))
+  async (params) => {
+    const { text, structured } = await walkMemoryGraph(memRepo, edgesRepo, params);
+    return { content: [{ type: "text" as const, text }], structuredContent: structured };
+  }
 );
 
 server.registerTool(
@@ -741,10 +797,20 @@ server.registerTool(
       openWorldHint: false,
     },
     outputSchema: {
-      message: z.string().describe("Path rendered as `<title-A> -[<edge_type>]-> <title-B> -[<edge_type>]-> ...` along with hop count, or `No path within <max_hops> hops.` Returns `Memory <id> not found.` when an endpoint is missing."),
+      found: z.boolean().describe("`true` when a path exists within `max_hops`; `false` otherwise (in which case `path` is empty and `message` carries the reason)."),
+      hops: z.number().int().nonnegative().describe("Number of edges in the path. 0 when `from_id === to_id`."),
+      path: z.array(z.object({
+        id: z.string().describe("Memory id of this node along the path."),
+        title: z.string().describe("Memory title (or id when the memory has been deleted)."),
+        edge_type_to_next: edgeTypeEnum.optional().describe("The edge type linking this node to the next one in the path. Absent on the final node."),
+      })).describe("Ordered list of nodes from `from_id` to `to_id`, each annotated with the edge type that takes you to the next node."),
+      message: z.string().optional().describe("Human-readable failure reason when `found=false` (e.g. `No path from <a> to <b> within <n> hops`)."),
     },
   },
-  async (params) => textResult(await handleMemoryPath(memRepo, edgesRepo, params))
+  async (params) => {
+    const { text, structured } = await findMemoryPath(memRepo, edgesRepo, params);
+    return { content: [{ type: "text" as const, text }], structuredContent: structured };
+  }
 );
 
 async function main(): Promise<void> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -171,16 +171,28 @@ process.on("SIGINT", shutdown);
 
 const server = new McpServer({ name: "memento-mcp", version: "2.1.6" });
 
+/**
+ * Wraps a string handler result into the shape the MCP SDK expects when an
+ * `outputSchema` is declared. We always return both:
+ *   • `content` (text)            — for clients that render plain text
+ *   • `structuredContent.message` — validated against `outputSchema`
+ * Tools opt into a richer outputSchema by defining their own shape.
+ */
+function textResult(message: string) {
+  return {
+    content: [{ type: "text" as const, text: message }],
+    structuredContent: { message },
+  };
+}
+
 server.registerTool(
   "memory_store",
   {
     title: "Store a memory",
     description: [
-      "Persist a fact, decision, lesson, or pattern into the local SQLite memory store so it can be recalled later by `memory_search`, `memory_get`, or injected automatically into future sessions.",
-      "When to use: capturing a durable piece of context (architecture decision, gotcha, user preference, recurring command, important fact). Use this for anything you'd otherwise have to re-derive from chat history.",
-      "When NOT to use: transient debug output, temporary scratch notes, or content that already lives in the codebase — search first with `memory_search` to avoid duplicates, or run `memory_dedup_check` for a cheap pre-flight.",
-      "Side effects: writes a row to SQLite (and queues an embedding when enabled); may also create/update an Obsidian vault note when `persist_to_vault=true` or when project policy auto-promotes the type. Returns the new memory id.",
-      "Dedup: when embeddings are enabled, near-duplicates are detected; pass `dedup=\"strict\"` to refuse storing duplicates, `\"warn\"` to store with a warning, or `\"off\"` to bypass.",
+      "Persist a fact, decision, lesson, or pattern so it can be recalled later by `memory_search`/`memory_get` or auto-injected into future sessions.",
+      "Use for durable context (decisions, gotchas, preferences, recurring commands). For transient notes or duplicates, prefer `memory_dedup_check` first.",
+      "Writes one SQLite row, queues an embedding (when enabled), and optionally creates/updates an Obsidian vault note. `dedup=\"strict\"` refuses duplicates, `\"warn\"` stores with a warning, `\"off\"` bypasses.",
     ].join(" "),
     inputSchema: {
       title: z.string().min(1).describe("Short human-readable title (1 line). Used as the search label and as the vault note filename when promoted."),
@@ -206,10 +218,11 @@ server.registerTool(
       idempotentHint: false,
       openWorldHint: false,
     },
+    outputSchema: {
+      message: z.string().describe("On success: `Memory stored with ID: <id>` (optionally followed by a vault-note path or a dedup `⚠` warning). On rejection: `Memory not stored: <reason>` explaining policy/dedup failure."),
+    },
   },
-  async (params) => ({
-    content: [{ type: "text" as const, text: await handleMemoryStore(memRepo, params, db, config, embRepo) }],
-  })
+  async (params) => textResult(await handleMemoryStore(memRepo, params, db, config, embRepo))
 );
 
 server.registerTool(
@@ -217,13 +230,9 @@ server.registerTool(
   {
     title: "Search memories",
     description: [
-      "Ranked full-text + decay-weighted search across the local memory store, optional file-memory sources, and (when configured) the Obsidian vault.",
-      "Use the three-layer progressive-disclosure pattern to keep token costs low:",
-      "  • `detail=\"index\"` (default, cheapest) — titles + scores only, ~30 tokens per result. Start here to triage candidates.",
-      "  • `detail=\"summary\"` — title + short body preview, ~80 tokens per result. Use to shortlist.",
-      "  • `detail=\"full\"` — full body, ~150-300 tokens per result. Use sparingly, ideally on a single id.",
-      "Follow-ups: for chronological context around one hit, prefer `memory_timeline(id)` (~200 tokens per neighbour). For the full body of a known id, prefer `memory_get(id)` (~300-800 tokens).",
-      "Read-only — no rows are modified. Records an analytics event when analytics are enabled.",
+      "Ranked full-text + decay-weighted search across SQLite, file-memory sources, and (when configured) the Obsidian vault. Read-only.",
+      "Use the three-layer progressive-disclosure pattern: `detail=\"index\"` (~30 tok/result, start here), `\"summary\"` (~80 tok), `\"full\"` (~150-300 tok, use sparingly).",
+      "Follow-ups: `memory_timeline(id)` for chronological neighbours of one hit, `memory_get(id)` for one full body, `memory_graph(id)` to explore typed edges.",
     ].join(" "),
     inputSchema: {
       query: z.string().min(1).describe("Free-text query. Tokenised by FTS5; phrases match individual terms. Examples: `\"oauth refresh\"`, `\"why we picked postgres\"`."),
@@ -240,10 +249,11 @@ server.registerTool(
       idempotentHint: true,
       openWorldHint: false,
     },
+    outputSchema: {
+      message: z.string().describe("Markdown-formatted ranked results at the requested `detail` level. Empty result set is rendered as `No results found.` Vault hits, when present, are appended in a separate section."),
+    },
   },
-  async (params) => ({
-    content: [{ type: "text" as const, text: await handleMemorySearch(memRepo, config, params, db, analyticsTracker) }],
-  })
+  async (params) => textResult(await handleMemorySearch(memRepo, config, params, db, analyticsTracker))
 );
 
 server.registerTool(
@@ -251,10 +261,9 @@ server.registerTool(
   {
     title: "Get full memory by id",
     description: [
-      "Fetch the full body, tags, and metadata of a single memory by its id (~300-800 tokens). Read-only.",
-      "Workflow: call `memory_search` first (with `detail=\"index\"`) to find the id, then call this for the full content.",
-      "Privacy: substrings inside `<private>...</private>` tags are redacted by default. Pass `reveal_private=true` to unmask them; this emits an audit event when analytics are enabled.",
-      "Returns a clear `not found` message if the id does not exist or has been soft-deleted.",
+      "Fetch the full body, tags, and metadata of one memory by id (~300-800 tokens). Read-only.",
+      "Use after `memory_search(detail=\"index\")` to expand a single hit. Substrings inside `<private>` tags are redacted unless `reveal_private=true` (which emits an audit event).",
+      "Returns `not found` if the id does not exist or has been soft-deleted.",
     ].join(" "),
     inputSchema: {
       memory_id: z.string().min(1).describe("The memory id, as returned by `memory_store` or shown in `memory_search` results (e.g. `mem_01HXYZ...`)."),
@@ -267,10 +276,11 @@ server.registerTool(
       idempotentHint: true,
       openWorldHint: false,
     },
+    outputSchema: {
+      message: z.string().describe("Full memory rendered as markdown (title, metadata, body). Returns `Memory <id> not found.` when missing."),
+    },
   },
-  async (params) => ({
-    content: [{ type: "text" as const, text: await handleMemoryGet(memRepo, db, config, params) }],
-  })
+  async (params) => textResult(await handleMemoryGet(memRepo, db, config, params))
 );
 
 server.registerTool(
@@ -278,9 +288,8 @@ server.registerTool(
   {
     title: "List memories around an id (chronological)",
     description: [
-      "Return the chronological neighbourhood of memories created around the given memory id — a cheap way to recover work-session context (~200 tokens per neighbour).",
-      "Workflow: run `memory_search(detail=\"index\")` first to pick a hit, then call `memory_timeline(id)` to see what was being captured around the same time. Cheaper than calling `memory_get` on each neighbour.",
-      "Read-only.",
+      "Return the chronological neighbourhood of memories around an anchor id (~200 tok/neighbour). Read-only.",
+      "Use after `memory_search(detail=\"index\")` to recover work-session context for one hit. Cheaper than calling `memory_get` on each neighbour individually.",
     ].join(" "),
     inputSchema: {
       id: z.string().min(1).describe("The anchor memory id to centre the window on. Get this from `memory_search` or `memory_store`."),
@@ -295,10 +304,11 @@ server.registerTool(
       idempotentHint: true,
       openWorldHint: false,
     },
+    outputSchema: {
+      message: z.string().describe("Markdown list of neighbour memories (anchor + window on each side) at the requested `detail` level. Returns `Memory <id> not found.` when the anchor is missing."),
+    },
   },
-  async (params) => ({
-    content: [{ type: "text" as const, text: await handleMemoryTimeline(memRepo, params) }],
-  })
+  async (params) => textResult(await handleMemoryTimeline(memRepo, params))
 );
 
 server.registerTool(
@@ -306,10 +316,9 @@ server.registerTool(
   {
     title: "Check for near-duplicate memories",
     description: [
-      "Cheap pre-flight (~50 tokens per match) that asks: \"if I were to store this content, would it duplicate something I already have?\"",
-      "Returns up to `limit` existing memories whose cosine similarity to the candidate text is above the threshold, sorted by similarity descending.",
-      "Use before `memory_store` when you suspect overlap, or before bulk imports. If embeddings are disabled in config, returns a clear no-op message — it does not silently skip the check.",
-      "Read-only — no rows are written. Computing the candidate embedding may make an outbound call to the embeddings provider (OpenAI, Ollama, etc.) when one is configured.",
+      "Cheap pre-flight (~50 tok/match): \"would storing this content duplicate something I already have?\" Read-only.",
+      "Use before `memory_store` when overlap is likely, or before bulk imports. Returns up to `limit` existing memories with cosine similarity above the threshold (highest first).",
+      "Computing the candidate embedding may make an outbound call to the configured provider (OpenAI, Ollama, etc.). If embeddings are disabled, returns a clear no-op message rather than silently passing.",
     ].join(" "),
     inputSchema: {
       content: z.string().min(1).describe("Candidate memory body to check, exactly as you would pass to `memory_store`."),
@@ -325,10 +334,11 @@ server.registerTool(
       idempotentHint: true,
       openWorldHint: true,
     },
+    outputSchema: {
+      message: z.string().describe("Markdown list of near-duplicate matches with similarity scores, or `No near-duplicates found above threshold.` Returns a no-op message when embeddings are disabled in config."),
+    },
   },
-  async (params) => ({
-    content: [{ type: "text" as const, text: await handleMemoryDedupCheck(db, memRepo, embRepo, dedupProvider, config, params) }]
-  })
+  async (params) => textResult(await handleMemoryDedupCheck(db, memRepo, embRepo, dedupProvider, config, params))
 );
 
 server.registerTool(
@@ -336,10 +346,8 @@ server.registerTool(
   {
     title: "List memories (no query)",
     description: [
-      "Browse stored memories with optional filters — use this when you want to enumerate by type/scope/project rather than run a search query.",
-      "Differs from `memory_search`: there is no text query and ordering is by recency/importance rather than relevance. Prefer `memory_search` whenever you have keywords.",
-      "Use the same `detail` progressive-disclosure levels as `memory_search` to control token cost.",
-      "Read-only.",
+      "Browse stored memories with optional filters — ordered by recency/importance. Read-only.",
+      "Use to enumerate by type/scope/project. Prefer `memory_search` whenever you have keywords (relevance ranking). Use the same `detail` levels to control token cost.",
     ].join(" "),
     inputSchema: {
       project_path: z.string().default("").describe("Optional absolute project path filter. Empty string lists across all projects."),
@@ -359,10 +367,11 @@ server.registerTool(
       idempotentHint: true,
       openWorldHint: false,
     },
+    outputSchema: {
+      message: z.string().describe("Markdown-formatted list at the requested `detail` level, or `No memories found.` Vault notes appear in a separate section when included."),
+    },
   },
-  async (params) => ({
-    content: [{ type: "text" as const, text: await handleMemoryList(memRepo, config, params, db) }],
-  })
+  async (params) => textResult(await handleMemoryList(memRepo, config, params, db))
 );
 
 server.registerTool(
@@ -370,9 +379,8 @@ server.registerTool(
   {
     title: "Delete a memory (soft)",
     description: [
-      "Soft-delete a single memory by id. The row is marked deleted (and excluded from search/list/get) but is retained in the database for audit and recovery.",
-      "Use when a memory is wrong, obsolete, or accidental. To replace one memory with a corrected version, prefer `memory_store(supersedes_id=...)` instead so the history is linked.",
-      "Idempotent: deleting an already-deleted id returns a clear message and is a no-op.",
+      "Soft-delete a memory by id — the row is hidden from search/list/get but retained for audit. Idempotent.",
+      "Use for accidental or obsolete memories. To replace one with a corrected version, prefer `memory_store(supersedes_id=...)` so history is linked.",
     ].join(" "),
     inputSchema: {
       memory_id: z.string().min(1).describe("Id of the memory to soft-delete (e.g. `mem_01HXYZ...`)."),
@@ -384,10 +392,11 @@ server.registerTool(
       idempotentHint: true,
       openWorldHint: false,
     },
+    outputSchema: {
+      message: z.string().describe("`Memory <id> deleted.` on success, `Memory <id> not found.` when the id is missing."),
+    },
   },
-  async (params) => ({
-    content: [{ type: "text" as const, text: await handleMemoryDelete(memRepo, params) }],
-  })
+  async (params) => textResult(await handleMemoryDelete(memRepo, params))
 );
 
 server.registerTool(
@@ -395,12 +404,11 @@ server.registerTool(
   {
     title: "Architectural decision log",
     description: [
-      "Multi-action endpoint for the project's architectural decision record (ADR) log. Pick one of the following via `action`:",
-      "  • `store` — record a new decision; requires `title` and `body` (and optionally `supersedes_id` to mark a previous decision as superseded).",
-      "  • `list` — list recent decisions; respects `limit`.",
-      "  • `search` — full-text search over decisions; requires `query`.",
-      "Decisions are higher-importance by default than free-form memories and are intended to outlive normal pruning. Use `pitfalls_log` for recurring problems instead of decisions.",
-      "Side effects: `store` writes to the decisions table (and links a `supersedes` edge when `supersedes_id` is provided). `list` and `search` are read-only.",
+      "Multi-action ADR log. Pick one via `action`:",
+      "  • `store` — record a new decision (`title` + `body` required; `supersedes_id` optional). Writes a row.",
+      "  • `list` — list recent decisions (read-only).",
+      "  • `search` — FTS over decisions (`query` required, read-only).",
+      "Decisions outrank free-form memories by default and survive pruning longer. Use `pitfalls_log` for recurring problems.",
     ].join(" "),
     inputSchema: {
       action: z.enum(["store", "list", "search"]).describe("Which sub-operation to perform: `store`, `list`, or `search`."),
@@ -420,10 +428,11 @@ server.registerTool(
       idempotentHint: false,
       openWorldHint: false,
     },
+    outputSchema: {
+      message: z.string().describe("For `store`: `Decision stored with ID: <id>`. For `list`/`search`: markdown bullet list of decisions or `No decisions found.` Returns `Invalid action: ...` when `action` is unsupported."),
+    },
   },
-  async (params) => ({
-    content: [{ type: "text" as const, text: await handleDecisionsLog(decRepo, params) }],
-  })
+  async (params) => textResult(await handleDecisionsLog(decRepo, params))
 );
 
 server.registerTool(
@@ -431,12 +440,11 @@ server.registerTool(
   {
     title: "Recurring pitfalls log",
     description: [
-      "Multi-action endpoint for tracking recurring problems and their resolutions. Pick one via `action`:",
-      "  • `store` — record a new pitfall; requires `title` and `body` describing the symptom and the fix.",
-      "  • `list` — list open pitfalls (or all when `include_resolved=true`).",
-      "  • `resolve` — mark a pitfall as resolved; requires `pitfall_id`.",
-      "Use this instead of `memory_store` when something keeps biting and you want a dedicated, queryable log of \"problem → resolution\" pairs. For one-off design choices, use `decisions_log`.",
-      "Side effects: `store` and `resolve` write to the pitfalls table; `list` is read-only.",
+      "Multi-action log of recurring problems and their resolutions. Pick one via `action`:",
+      "  • `store` — record a new pitfall (`title` + `body` required). Writes a row.",
+      "  • `list` — list open pitfalls (set `include_resolved=true` for all). Read-only.",
+      "  • `resolve` — mark a pitfall resolved (`pitfall_id` required).",
+      "Use when something keeps biting and you want a queryable problem→resolution log. For one-off design choices, use `decisions_log`.",
     ].join(" "),
     inputSchema: {
       action: z.enum(["store", "list", "resolve"]).describe("Which sub-operation to perform: `store`, `list`, or `resolve`."),
@@ -455,10 +463,11 @@ server.registerTool(
       idempotentHint: false,
       openWorldHint: false,
     },
+    outputSchema: {
+      message: z.string().describe("For `store`: `Pitfall logged/updated with ID: <id>`. For `list`: markdown list with `[RESOLVED]` or `[xN]` (occurrence count) prefixes, or `No pitfalls found.` For `resolve`: `Pitfall <id> marked as resolved.` or `Pitfall <id> not found.`"),
+    },
   },
-  async (params) => ({
-    content: [{ type: "text" as const, text: await handlePitfallsLog(pitRepo, params) }],
-  })
+  async (params) => textResult(await handlePitfallsLog(pitRepo, params))
 );
 
 server.registerTool(
@@ -466,9 +475,8 @@ server.registerTool(
   {
     title: "Memory effectiveness analytics",
     description: [
-      "Report on how the memory system is performing: utility rates of injected memories, token costs of search layers, auto-capture statistics, compression activity, and prune suggestions.",
-      "Use to tune importance thresholds, find dead memories worth pruning, and verify that auto-capture/compression are pulling their weight.",
-      "Read-only. Returns an empty/no-op-style report when analytics are disabled in config.",
+      "Reports utility rates of injected memories, token costs per search layer, auto-capture stats, compression activity, and prune suggestions. Read-only.",
+      "Use to tune importance thresholds, find dead memories worth pruning, and verify that auto-capture/compression are earning their keep. Returns a no-op message when analytics are disabled.",
     ].join(" "),
     inputSchema: {
       period: z.enum(["last_24h", "last_7d", "last_30d", "all"]).default("last_7d").describe("Time window to summarise. `all` covers the full retention period configured in `analytics.retentionDays`."),
@@ -482,10 +490,11 @@ server.registerTool(
       idempotentHint: true,
       openWorldHint: false,
     },
+    outputSchema: {
+      message: z.string().describe("Markdown report grouped by `section` (`injections` / `captures` / `compression` / `memories`) with totals, percentages, and prune candidates. Returns a no-op message when analytics are disabled in config."),
+    },
   },
-  async (params) => ({
-    content: [{ type: "text" as const, text: await handleMemoryAnalytics(db, params) }],
-  })
+  async (params) => textResult(await handleMemoryAnalytics(db, params))
 );
 
 server.registerTool(
@@ -493,10 +502,9 @@ server.registerTool(
   {
     title: "Update a memory in place",
     description: [
-      "Edit a single memory in place. Only the fields you pass are changed; omitted fields are left untouched.",
-      "Editable fields: `title`, `content`, `tags`, `importance`, `memory_type`, `pinned`. Side effects when the textual content changes: the embedding is re-queued and dedup may run.",
-      "Prefer `memory_store(supersedes_id=...)` instead of in-place edits when the change is significant enough that you'd want history (e.g. a reversed decision). Use this tool for typo fixes, retagging, importance tuning, and similar minor edits.",
-      "Returns a clear `not found` message if the id does not exist.",
+      "Edit a memory in place — only the fields you pass are changed. Editable: `title`, `content`, `tags`, `importance`, `memory_type`, `pinned`.",
+      "Use for typo fixes, retagging, importance tuning. For meaningful changes you'd want history for (e.g. a reversed decision), prefer `memory_store(supersedes_id=...)` instead.",
+      "Side effect: when `content` changes, the embedding is re-queued and dedup may run. Returns `not found` for missing ids.",
     ].join(" "),
     inputSchema: {
       memory_id: z.string().min(1).describe("Id of the memory to update (e.g. `mem_01HXYZ...`)."),
@@ -515,10 +523,11 @@ server.registerTool(
       idempotentHint: true,
       openWorldHint: false,
     },
+    outputSchema: {
+      message: z.string().describe("`Memory <id> updated.` on success, `Memory <id> not found.` when missing, or a dedup-rejection sentence when `dedup=\"strict\"` blocks the change."),
+    },
   },
-  async (params) => ({
-    content: [{ type: "text" as const, text: await handleMemoryUpdate(memRepo, params, config, embRepo) }],
-  })
+  async (params) => textResult(await handleMemoryUpdate(memRepo, params, config, embRepo))
 );
 
 server.registerTool(
@@ -526,9 +535,8 @@ server.registerTool(
   {
     title: "Pin or unpin a memory",
     description: [
-      "Toggle the pinned flag on a memory. Pinned memories are exempt from automatic pruning and rank higher in search.",
-      "Use sparingly — pinning everything defeats the purpose. Reserve pins for canonical decisions, user preferences, and high-leverage facts you want to survive even long retention windows.",
-      "Idempotent: pinning an already-pinned memory (or unpinning an already-unpinned one) is a no-op.",
+      "Toggle the pinned flag — pinned memories survive pruning and rank higher in search. Idempotent.",
+      "Use sparingly: reserve pins for canonical decisions, user preferences, and high-leverage facts. Pinning everything defeats the purpose.",
     ].join(" "),
     inputSchema: {
       memory_id: z.string().min(1).describe("Id of the memory to pin or unpin."),
@@ -541,10 +549,11 @@ server.registerTool(
       idempotentHint: true,
       openWorldHint: false,
     },
+    outputSchema: {
+      message: z.string().describe("`Memory <id> pinned.` / `Memory <id> unpinned.` on success, `Memory <id> not found.` when missing."),
+    },
   },
-  async (params) => ({
-    content: [{ type: "text" as const, text: await handleMemoryPin(memRepo, params) }],
-  })
+  async (params) => textResult(await handleMemoryPin(memRepo, params))
 );
 
 server.registerTool(
@@ -552,10 +561,9 @@ server.registerTool(
   {
     title: "Run the compression pipeline now",
     description: [
-      "Run an on-demand compression cycle: cluster similar memories by embedding similarity, merge each cluster into a single canonical memory, and mark the originals as compressed.",
-      "Normally compression runs automatically on the maintenance schedule. Call this tool when you want to force a pass — e.g. right after a bulk import, or to sanity-check compression behaviour.",
-      "Side effects: writes new merged memories and updates the originals' `compressed_into` pointer. Requires `compression.enabled=true` in config; otherwise returns a clear no-op message. May call the configured embeddings + LLM providers.",
-      "Returns a summary of how many clusters were compressed in each project.",
+      "Force one compression cycle now: cluster similar memories by embedding similarity, merge each cluster into a canonical memory, and mark originals as compressed.",
+      "Use after a bulk import or to sanity-check compression. Compression normally runs on the maintenance schedule.",
+      "Side effects: writes merged memories, updates originals' `compressed_into` pointer, may call embeddings + LLM providers. Requires `compression.enabled=true`; otherwise returns a no-op message.",
     ].join(" "),
     inputSchema: {
       project_path: z.string().default("").describe("Absolute project path to compress. Empty string (default) compresses every project."),
@@ -567,10 +575,11 @@ server.registerTool(
       idempotentHint: false,
       openWorldHint: true,
     },
+    outputSchema: {
+      message: z.string().describe("Summary line per project, e.g. `Compressed 3 cluster(s) in project <id>`, or `No clusters to compress.` Returns a no-op message when `compression.enabled=false`."),
+    },
   },
-  async (params) => ({
-    content: [{ type: "text" as const, text: await handleMemoryCompress(db, config, params) }],
-  })
+  async (params) => textResult(await handleMemoryCompress(db, config, params))
 );
 
 server.registerTool(
@@ -578,9 +587,8 @@ server.registerTool(
   {
     title: "Export memories as JSON",
     description: [
-      "Export memories, decisions, and pitfalls as a portable JSON document, suitable for backup, transfer to another machine, or import into another memento-mcp instance via `memory_import`.",
-      "Use before any destructive maintenance (bulk delete, schema migration) so you have a clean restore point. The export includes scope, tags, importance, and supersession links so a round-trip preserves structure.",
-      "Read-only — does not modify any rows. Returns the JSON inline in the tool response.",
+      "Export memories, decisions, and pitfalls as a portable JSON document. Read-only.",
+      "Use before destructive maintenance (bulk delete, schema migration) so you have a clean restore point, or to transfer state to another memento-mcp instance via `memory_import`. Includes scope, tags, importance, and supersession links so round-trip preserves structure.",
     ].join(" "),
     inputSchema: {
       project_path: z.string().default("").describe("Absolute project path to export. Empty string (default) exports memories across all projects."),
@@ -592,10 +600,11 @@ server.registerTool(
       idempotentHint: true,
       openWorldHint: false,
     },
+    outputSchema: {
+      message: z.string().describe("JSON document (as a string) containing `memories`, `decisions`, and `pitfalls` arrays plus a `meta` object with export timestamp and scope."),
+    },
   },
-  async (params) => ({
-    content: [{ type: "text" as const, text: await handleMemoryExport(db, params) }],
-  })
+  async (params) => textResult(await handleMemoryExport(db, params))
 );
 
 server.registerTool(
@@ -603,12 +612,9 @@ server.registerTool(
   {
     title: "Import memories from JSON",
     description: [
-      "Import memories, decisions, and pitfalls from a JSON file previously produced by `memory_export`. The file must be readable from the path given (server-local filesystem, not a URL).",
-      "Conflict handling via `strategy`:",
-      "  • `skip` (default) — keep existing rows when ids collide; only insert missing ones. Safe to re-run.",
-      "  • `overwrite` — replace existing rows on id collisions. Use for authoritative restores.",
-      "Side effects: inserts/updates rows in `memories`, `decisions`, and `pitfalls`. Embeddings are queued asynchronously after import.",
-      "Returns counts of rows inserted, updated, and skipped.",
+      "Import memories, decisions, and pitfalls from a JSON file produced by `memory_export` (server-local path, not a URL).",
+      "Conflict handling via `strategy`: `skip` (default, safe to re-run) keeps existing rows on id collision; `overwrite` replaces them — use for authoritative restores.",
+      "Side effects: inserts/updates rows in `memories`, `decisions`, `pitfalls`. Embeddings are queued asynchronously.",
     ].join(" "),
     inputSchema: {
       path: z.string().min(1).describe("Absolute path on the server's filesystem to a JSON file produced by `memory_export` (e.g. `/tmp/memento-backup.json`)."),
@@ -621,10 +627,11 @@ server.registerTool(
       idempotentHint: false,
       openWorldHint: false,
     },
+    outputSchema: {
+      message: z.string().describe("Summary line with counts of rows inserted / updated / skipped per table (memories, decisions, pitfalls)."),
+    },
   },
-  async (params) => ({
-    content: [{ type: "text" as const, text: await handleMemoryImport(db, params) }],
-  })
+  async (params) => textResult(await handleMemoryImport(db, params))
 );
 
 const edgeTypeEnum = z.enum(["relates_to", "supersedes", "caused_by", "mitigated_by", "references", "implements"]);
@@ -634,10 +641,8 @@ server.registerTool(
   {
     title: "Link two memories with a typed edge",
     description: [
-      "Create a typed directed edge from one memory to another in the knowledge graph. Use the resulting graph to map dependencies, supersession chains, cause/effect, and references.",
-      "Supported edge types: `relates_to`, `supersedes`, `caused_by`, `mitigated_by`, `references`, `implements`.",
-      "Workflow: call `memory_search` (or `memory_list`) first to find the two ids, then `memory_link` to connect them. Re-linking the same `(from_id, to_id, edge_type)` triple updates its weight rather than creating a duplicate.",
-      "Side effects: writes a row to the edges table.",
+      "Create a typed directed edge between two memories. Edge types: `relates_to`, `supersedes`, `caused_by`, `mitigated_by`, `references`, `implements`.",
+      "Use after `memory_search` to map dependencies, cause/effect, supersession chains, or references. Re-linking the same `(from_id, to_id, edge_type)` triple updates the weight (idempotent).",
     ].join(" "),
     inputSchema: {
       from_id: z.string().min(1).describe("Source memory id (the edge points outward from this memory)."),
@@ -652,10 +657,11 @@ server.registerTool(
       idempotentHint: true,
       openWorldHint: false,
     },
+    outputSchema: {
+      message: z.string().describe("`Edge created/updated: <from> -[<edge_type>:<weight>]-> <to>` on success, or `Memory <id> not found.` when either endpoint is missing."),
+    },
   },
-  async (params) => ({
-    content: [{ type: "text" as const, text: await handleMemoryLink(memRepo, edgesRepo, params) }],
-  })
+  async (params) => textResult(await handleMemoryLink(memRepo, edgesRepo, params))
 );
 
 server.registerTool(
@@ -663,9 +669,8 @@ server.registerTool(
   {
     title: "Remove an edge between two memories",
     description: [
-      "Remove a previously created edge from the knowledge graph. You must pass the exact `(from_id, to_id, edge_type)` triple used when the edge was created — `memory_unlink` does not remove arbitrary or wildcard edges.",
-      "Idempotent: removing a non-existent edge returns a clear message and is a no-op.",
-      "Use this to retract incorrect links; for retracting an entire memory, prefer `memory_delete` (which leaves the audit trail intact).",
+      "Remove a previously created edge — pass the exact `(from_id, to_id, edge_type)` triple used at creation time. No wildcards. Idempotent.",
+      "Use to retract incorrect links. To retract a whole memory, prefer `memory_delete` (keeps audit trail).",
     ].join(" "),
     inputSchema: {
       from_id: z.string().min(1).describe("Source memory id of the edge to remove."),
@@ -679,10 +684,11 @@ server.registerTool(
       idempotentHint: true,
       openWorldHint: false,
     },
+    outputSchema: {
+      message: z.string().describe("`Edge removed: <from> -[<edge_type>]-> <to>` on success, or `Edge not found.` when the triple does not exist."),
+    },
   },
-  async (params) => ({
-    content: [{ type: "text" as const, text: await handleMemoryUnlink(edgesRepo, params) }],
-  })
+  async (params) => textResult(await handleMemoryUnlink(edgesRepo, params))
 );
 
 server.registerTool(
@@ -690,10 +696,8 @@ server.registerTool(
   {
     title: "Explore the knowledge graph around a memory",
     description: [
-      "Breadth-first walk of the knowledge graph rooted at one memory id. Returns the root plus its neighbour nodes (titles + ids) and the typed edges between them.",
-      "Use to map related concepts, surface supersession chains, or visualise the cluster around a decision. Chain pattern: `memory_search` → `memory_graph` to expand the most relevant hit.",
-      "Direction control: `out` follows outgoing edges only, `in` follows incoming, `both` (default) follows all.",
-      "Depth 0 returns just the root node; max depth is 5 to keep results bounded. Read-only.",
+      "BFS walk from one memory id outward, returning neighbour nodes + typed edges. Read-only.",
+      "Use after `memory_search` to map related concepts, supersession chains, or the cluster around a decision. `direction` controls edge polarity (`out`/`in`/`both`); depth is capped at 5.",
     ].join(" "),
     inputSchema: {
       id: z.string().min(1).describe("Memory id to use as the root of the BFS walk."),
@@ -708,10 +712,11 @@ server.registerTool(
       idempotentHint: true,
       openWorldHint: false,
     },
+    outputSchema: {
+      message: z.string().describe("Markdown rendering of the BFS frontier: root node + per-hop neighbours grouped by depth, each line showing edge type and target title. Returns `Memory <id> not found.` for a missing root."),
+    },
   },
-  async (params) => ({
-    content: [{ type: "text" as const, text: await handleMemoryGraph(memRepo, edgesRepo, params) }],
-  })
+  async (params) => textResult(await handleMemoryGraph(memRepo, edgesRepo, params))
 );
 
 server.registerTool(
@@ -719,9 +724,8 @@ server.registerTool(
   {
     title: "Shortest path between two memories",
     description: [
-      "Find the shortest path (smallest number of hops) between two memories in the knowledge graph using BFS. Returns the chain of memory ids and the edge types that connect them, or a clear `no path` message.",
-      "Use to trace cause-effect chains, supersession history, or dependency lineage. Chain pattern: `memory_search` → `memory_path` once you know both endpoints.",
-      "Read-only.",
+      "BFS shortest path between two memories — returns the chain of ids + edge types, or a `no path` message when unreachable within `max_hops`. Read-only.",
+      "Use after `memory_search` (with both endpoints known) to trace cause-effect chains, supersession history, or dependency lineage.",
     ].join(" "),
     inputSchema: {
       from_id: z.string().min(1).describe("Starting memory id."),
@@ -736,10 +740,11 @@ server.registerTool(
       idempotentHint: true,
       openWorldHint: false,
     },
+    outputSchema: {
+      message: z.string().describe("Path rendered as `<title-A> -[<edge_type>]-> <title-B> -[<edge_type>]-> ...` along with hop count, or `No path within <max_hops> hops.` Returns `Memory <id> not found.` when an endpoint is missing."),
+    },
   },
-  async (params) => ({
-    content: [{ type: "text" as const, text: await handleMemoryPath(memRepo, edgesRepo, params) }],
-  })
+  async (params) => textResult(await handleMemoryPath(memRepo, edgesRepo, params))
 );
 
 async function main(): Promise<void> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -169,245 +169,458 @@ function shutdown(): void {
 process.on("SIGTERM", shutdown);
 process.on("SIGINT", shutdown);
 
-const server = new McpServer({ name: "memento-mcp", version: "1.0.0" });
+const server = new McpServer({ name: "memento-mcp", version: "2.1.6" });
 
-server.tool(
+server.registerTool(
   "memory_store",
-  "Persist a typed memory in SQLite, with optional promotion to the Obsidian vault.",
   {
-    title: z.string(),
-    content: z.string(),
-    memory_type: z.string().default("fact"),
-    scope: z.string().default("project"),
-    project_path: z.string().default(""),
-    tags: z.array(z.string()).default([]),
-    importance: z.number().default(0.5),
-    supersedes_id: z.string().default(""),
-    pin: z.boolean().default(false),
-    persist_to_vault: z.boolean().optional(),
-    vault_mode: z.enum(["create", "create_or_update"]).default("create_or_update"),
-    vault_kind: z.string().default(""),
-    vault_folder: z.string().default(""),
-    vault_note_title: z.string().default(""),
-    dedup: z.enum(["strict", "warn", "off"]).optional(),
+    title: "Store a memory",
+    description: [
+      "Persist a fact, decision, lesson, or pattern into the local SQLite memory store so it can be recalled later by `memory_search`, `memory_get`, or injected automatically into future sessions.",
+      "When to use: capturing a durable piece of context (architecture decision, gotcha, user preference, recurring command, important fact). Use this for anything you'd otherwise have to re-derive from chat history.",
+      "When NOT to use: transient debug output, temporary scratch notes, or content that already lives in the codebase — search first with `memory_search` to avoid duplicates, or run `memory_dedup_check` for a cheap pre-flight.",
+      "Side effects: writes a row to SQLite (and queues an embedding when enabled); may also create/update an Obsidian vault note when `persist_to_vault=true` or when project policy auto-promotes the type. Returns the new memory id.",
+      "Dedup: when embeddings are enabled, near-duplicates are detected; pass `dedup=\"strict\"` to refuse storing duplicates, `\"warn\"` to store with a warning, or `\"off\"` to bypass.",
+    ].join(" "),
+    inputSchema: {
+      title: z.string().min(1).describe("Short human-readable title (1 line). Used as the search label and as the vault note filename when promoted."),
+      content: z.string().min(1).describe("The memory body in markdown. Wrap sensitive substrings in `<private>...</private>` tags to redact them from default reads."),
+      memory_type: z.string().default("fact").describe("Category tag: `fact`, `decision`, `lesson`, `pattern`, `preference`, `command`, etc. Drives auto-promotion and importance defaults via project policy."),
+      scope: z.string().default("project").describe("Visibility scope: `project` (default, scoped to the project at `project_path`), `global` (all projects), or `team` (synced via git when sync is enabled)."),
+      project_path: z.string().default("").describe("Absolute filesystem path of the project this memory belongs to. Empty string defaults to the server's current working directory."),
+      tags: z.array(z.string()).default([]).describe("Free-form tag list, e.g. `[\"auth\", \"oauth2\"]`. Project policies may require certain tags or ban others."),
+      importance: z.number().min(0).max(1).default(0.5).describe("Importance score in [0, 1]. Higher values rank earlier in search and survive pruning longer. Default 0.5."),
+      supersedes_id: z.string().default("").describe("Optional id of an older memory that this one replaces. The older memory is marked superseded and de-prioritised in search."),
+      pin: z.boolean().default(false).describe("If true, pin the memory so it is exempt from automatic pruning and ranks higher."),
+      persist_to_vault: z.boolean().optional().describe("If true, also write an Obsidian vault note. If omitted, the project's policy decides based on `memory_type`."),
+      vault_mode: z.enum(["create", "create_or_update"]).default("create_or_update").describe("`create` fails if the note exists; `create_or_update` (default) overwrites an existing note with the same title."),
+      vault_kind: z.string().default("").describe("Optional vault subtype (e.g. `architecture`, `runbook`) used to pick a folder per `vault.kindFolders` config."),
+      vault_folder: z.string().default("").describe("Optional explicit vault subfolder, relative to the vault root. Overrides `vault_kind` routing."),
+      vault_note_title: z.string().default("").describe("Optional override for the vault note title. Defaults to `title` when empty."),
+      dedup: z.enum(["strict", "warn", "off"]).optional().describe("Per-call override for duplicate handling. Defaults to the server's `search.embeddings.dedupDefaultMode` when omitted."),
+    },
+    annotations: {
+      title: "Store a memory",
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: false,
+    },
   },
   async (params) => ({
     content: [{ type: "text" as const, text: await handleMemoryStore(memRepo, params, db, config, embRepo) }],
   })
 );
 
-server.tool(
+server.registerTool(
   "memory_search",
-  [
-    "Search memories with progressive disclosure.",
-    "Layer 1 (cheapest): detail='index' — titles + scores, ~30t per result. Start here.",
-    "Layer 2: detail='summary' — preview body, ~80t per result. Use to shortlist.",
-    "Layer 3: detail='full' — full body, ~150-300t per result. Use sparingly.",
-    "For chronological context around one hit, prefer memory_timeline(id) — ~200t per neighbor.",
-    "For one full body, prefer memory_get(id) — ~300-800t."
-  ].join(" "),
   {
-    query: z.string(),
-    project_path: z.string().default(""),
-    memory_type: z.string().default(""),
-    limit: z.number().default(10),
-    detail: z.enum(["index", "summary", "full"]).default("index"),
-    include_file_memories: z.boolean().default(true),
+    title: "Search memories",
+    description: [
+      "Ranked full-text + decay-weighted search across the local memory store, optional file-memory sources, and (when configured) the Obsidian vault.",
+      "Use the three-layer progressive-disclosure pattern to keep token costs low:",
+      "  • `detail=\"index\"` (default, cheapest) — titles + scores only, ~30 tokens per result. Start here to triage candidates.",
+      "  • `detail=\"summary\"` — title + short body preview, ~80 tokens per result. Use to shortlist.",
+      "  • `detail=\"full\"` — full body, ~150-300 tokens per result. Use sparingly, ideally on a single id.",
+      "Follow-ups: for chronological context around one hit, prefer `memory_timeline(id)` (~200 tokens per neighbour). For the full body of a known id, prefer `memory_get(id)` (~300-800 tokens).",
+      "Read-only — no rows are modified. Records an analytics event when analytics are enabled.",
+    ].join(" "),
+    inputSchema: {
+      query: z.string().min(1).describe("Free-text query. Tokenised by FTS5; phrases match individual terms. Examples: `\"oauth refresh\"`, `\"why we picked postgres\"`."),
+      project_path: z.string().default("").describe("Optional absolute project path to scope results. Empty string searches across all projects (subject to scope rules)."),
+      memory_type: z.string().default("").describe("Optional type filter, e.g. `decision`, `lesson`. Empty string returns all types."),
+      limit: z.number().int().min(1).max(50).default(10).describe("Maximum number of results to return (1-50). Default 10."),
+      detail: z.enum(["index", "summary", "full"]).default("index").describe("Disclosure level — `index` (cheapest), `summary`, or `full`. Always start at `index` and escalate only if needed."),
+      include_file_memories: z.boolean().default(true).describe("If true (default), also search markdown memory files registered as sources. Set false to limit to SQLite + vault."),
+    },
+    annotations: {
+      title: "Search memories",
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
   },
   async (params) => ({
     content: [{ type: "text" as const, text: await handleMemorySearch(memRepo, config, params, db, analyticsTracker) }],
   })
 );
 
-server.tool(
+server.registerTool(
   "memory_get",
-  "Fetch the full body of a single memory by id (~300-800 tokens). Prefer memory_search first to find the right id. Set reveal_private=true to see content inside <private> tags (emits an audit event).",
   {
-    memory_id: z.string(),
-    reveal_private: z.boolean().default(false),
+    title: "Get full memory by id",
+    description: [
+      "Fetch the full body, tags, and metadata of a single memory by its id (~300-800 tokens). Read-only.",
+      "Workflow: call `memory_search` first (with `detail=\"index\"`) to find the id, then call this for the full content.",
+      "Privacy: substrings inside `<private>...</private>` tags are redacted by default. Pass `reveal_private=true` to unmask them; this emits an audit event when analytics are enabled.",
+      "Returns a clear `not found` message if the id does not exist or has been soft-deleted.",
+    ].join(" "),
+    inputSchema: {
+      memory_id: z.string().min(1).describe("The memory id, as returned by `memory_store` or shown in `memory_search` results (e.g. `mem_01HXYZ...`)."),
+      reveal_private: z.boolean().default(false).describe("If true, include content inside `<private>` tags. Use only when explicitly necessary — emits an audit event."),
+    },
+    annotations: {
+      title: "Get full memory by id",
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
   },
   async (params) => ({
     content: [{ type: "text" as const, text: await handleMemoryGet(memRepo, db, config, params) }],
   })
 );
 
-server.tool(
+server.registerTool(
   "memory_timeline",
-  [
-    "Return memories created around a given memory id (chronological neighborhood).",
-    "Cost: ~200 tokens per neighbor.",
-    "Use after memory_search(detail='index') when you need work-session context for one specific hit.",
-    "Cheaper than calling memory_get on each neighbor individually."
-  ].join(" "),
   {
-    id: z.string(),
-    window: z.number().int().min(1).max(10).default(3),
-    detail: z.enum(["index", "summary"]).default("summary"),
-    same_session_only: z.boolean().default(true),
+    title: "List memories around an id (chronological)",
+    description: [
+      "Return the chronological neighbourhood of memories created around the given memory id — a cheap way to recover work-session context (~200 tokens per neighbour).",
+      "Workflow: run `memory_search(detail=\"index\")` first to pick a hit, then call `memory_timeline(id)` to see what was being captured around the same time. Cheaper than calling `memory_get` on each neighbour.",
+      "Read-only.",
+    ].join(" "),
+    inputSchema: {
+      id: z.string().min(1).describe("The anchor memory id to centre the window on. Get this from `memory_search` or `memory_store`."),
+      window: z.number().int().min(1).max(10).default(3).describe("Number of neighbours to return on each side (1-10). Default 3 → up to 6 neighbours total."),
+      detail: z.enum(["index", "summary"]).default("summary").describe("Disclosure level — `index` (titles only) or `summary` (titles + short preview, default). `full` is intentionally not offered here; use `memory_get` for that."),
+      same_session_only: z.boolean().default(true).describe("If true (default), only include neighbours captured in the same session as the anchor. Set false to span sessions."),
+    },
+    annotations: {
+      title: "List memories around an id (chronological)",
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
   },
   async (params) => ({
     content: [{ type: "text" as const, text: await handleMemoryTimeline(memRepo, params) }],
   })
 );
 
-server.tool(
+server.registerTool(
   "memory_dedup_check",
-  [
-    "Check if content is a near-duplicate of existing memories before storing.",
-    "Returns up to N matches above the cosine similarity threshold.",
-    "~50 tokens per result. Cheap pre-flight before memory_store.",
-    "If embeddings are disabled, returns a clear no-op message."
-  ].join(" "),
   {
-    content: z.string(),
-    title: z.string().optional(),
-    project_path: z.string().optional(),
-    threshold: z.number().min(0).max(1).optional(),
-    limit: z.number().int().min(1).max(20).default(5),
+    title: "Check for near-duplicate memories",
+    description: [
+      "Cheap pre-flight (~50 tokens per match) that asks: \"if I were to store this content, would it duplicate something I already have?\"",
+      "Returns up to `limit` existing memories whose cosine similarity to the candidate text is above the threshold, sorted by similarity descending.",
+      "Use before `memory_store` when you suspect overlap, or before bulk imports. If embeddings are disabled in config, returns a clear no-op message — it does not silently skip the check.",
+      "Read-only — no rows are written. Computing the candidate embedding may make an outbound call to the embeddings provider (OpenAI, Ollama, etc.) when one is configured.",
+    ].join(" "),
+    inputSchema: {
+      content: z.string().min(1).describe("Candidate memory body to check, exactly as you would pass to `memory_store`."),
+      title: z.string().optional().describe("Optional candidate title; concatenated with `content` to match how `memory_store` builds its embedding."),
+      project_path: z.string().optional().describe("Optional absolute project path to scope the search to a single project's memories."),
+      threshold: z.number().min(0).max(1).optional().describe("Cosine similarity threshold in [0, 1]. Defaults to `search.embeddings.dedupThreshold` from config (typically ~0.85)."),
+      limit: z.number().int().min(1).max(20).default(5).describe("Maximum number of matches to return (1-20). Default 5."),
+    },
+    annotations: {
+      title: "Check for near-duplicate memories",
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
   },
   async (params) => ({
     content: [{ type: "text" as const, text: await handleMemoryDedupCheck(db, memRepo, embRepo, dedupProvider, config, params) }]
   })
 );
 
-server.tool(
+server.registerTool(
   "memory_list",
-  "List memories with optional filters.",
   {
-    project_path: z.string().default(""),
-    memory_type: z.string().default(""),
-    scope: z.string().default(""),
-    pinned_only: z.boolean().default(false),
-    limit: z.number().default(20),
-    detail: z.enum(["index", "summary", "full"]).default("full"),
-    include_file_memories: z.boolean().default(false),
-    vault_kind: z.string().default(""),
-    vault_folder: z.string().default(""),
+    title: "List memories (no query)",
+    description: [
+      "Browse stored memories with optional filters — use this when you want to enumerate by type/scope/project rather than run a search query.",
+      "Differs from `memory_search`: there is no text query and ordering is by recency/importance rather than relevance. Prefer `memory_search` whenever you have keywords.",
+      "Use the same `detail` progressive-disclosure levels as `memory_search` to control token cost.",
+      "Read-only.",
+    ].join(" "),
+    inputSchema: {
+      project_path: z.string().default("").describe("Optional absolute project path filter. Empty string lists across all projects."),
+      memory_type: z.string().default("").describe("Optional type filter (e.g. `decision`). Empty string returns all types."),
+      scope: z.string().default("").describe("Optional scope filter — `project`, `global`, or `team`. Empty string returns all scopes."),
+      pinned_only: z.boolean().default(false).describe("If true, only return pinned memories."),
+      limit: z.number().int().min(1).max(200).default(20).describe("Maximum number of memories to return (1-200). Default 20."),
+      detail: z.enum(["index", "summary", "full"]).default("full").describe("Disclosure level — `index` (cheapest), `summary`, or `full` (default). Drop to `index` when listing many rows to keep token cost down."),
+      include_file_memories: z.boolean().default(false).describe("If true, also include markdown file-memory sources. Off by default since lists are usually about SQLite-backed memories."),
+      vault_kind: z.string().default("").describe("Optional vault subtype filter when listing vault notes."),
+      vault_folder: z.string().default("").describe("Optional vault subfolder filter (relative to vault root)."),
+    },
+    annotations: {
+      title: "List memories (no query)",
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
   },
   async (params) => ({
     content: [{ type: "text" as const, text: await handleMemoryList(memRepo, config, params, db) }],
   })
 );
 
-server.tool(
+server.registerTool(
   "memory_delete",
-  "Soft-delete a memory by ID.",
   {
-    memory_id: z.string(),
+    title: "Delete a memory (soft)",
+    description: [
+      "Soft-delete a single memory by id. The row is marked deleted (and excluded from search/list/get) but is retained in the database for audit and recovery.",
+      "Use when a memory is wrong, obsolete, or accidental. To replace one memory with a corrected version, prefer `memory_store(supersedes_id=...)` instead so the history is linked.",
+      "Idempotent: deleting an already-deleted id returns a clear message and is a no-op.",
+    ].join(" "),
+    inputSchema: {
+      memory_id: z.string().min(1).describe("Id of the memory to soft-delete (e.g. `mem_01HXYZ...`)."),
+    },
+    annotations: {
+      title: "Delete a memory (soft)",
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
   },
   async (params) => ({
     content: [{ type: "text" as const, text: await handleMemoryDelete(memRepo, params) }],
   })
 );
 
-server.tool(
+server.registerTool(
   "decisions_log",
-  "Store, list, or search architectural decisions.",
   {
-    action: z.string(),
-    project_path: z.string(),
-    title: z.string().default(""),
-    body: z.string().default(""),
-    category: z.string().default("general"),
-    importance: z.number().default(0.7),
-    supersedes_id: z.string().default(""),
-    query: z.string().default(""),
-    limit: z.number().default(10),
+    title: "Architectural decision log",
+    description: [
+      "Multi-action endpoint for the project's architectural decision record (ADR) log. Pick one of the following via `action`:",
+      "  • `store` — record a new decision; requires `title` and `body` (and optionally `supersedes_id` to mark a previous decision as superseded).",
+      "  • `list` — list recent decisions; respects `limit`.",
+      "  • `search` — full-text search over decisions; requires `query`.",
+      "Decisions are higher-importance by default than free-form memories and are intended to outlive normal pruning. Use `pitfalls_log` for recurring problems instead of decisions.",
+      "Side effects: `store` writes to the decisions table (and links a `supersedes` edge when `supersedes_id` is provided). `list` and `search` are read-only.",
+    ].join(" "),
+    inputSchema: {
+      action: z.enum(["store", "list", "search"]).describe("Which sub-operation to perform: `store`, `list`, or `search`."),
+      project_path: z.string().describe("Absolute project path the decision belongs to (or to scope `list`/`search`). Required."),
+      title: z.string().default("").describe("Decision title (required for `store`, ignored otherwise). One short line — e.g. `\"Use Postgres over MySQL\"`."),
+      body: z.string().default("").describe("Decision body in markdown (required for `store`). Should explain context, options considered, and rationale."),
+      category: z.string().default("general").describe("Free-form category tag for filtering, e.g. `architecture`, `infra`, `process`. Default `general`."),
+      importance: z.number().min(0).max(1).default(0.7).describe("Importance score in [0, 1] for `store`. Default 0.7 — decisions outrank typical facts (0.5)."),
+      supersedes_id: z.string().default("").describe("For `store`: optional id of an earlier decision this one replaces. The older decision is marked superseded."),
+      query: z.string().default("").describe("Search text (required for `action=\"search\"`). Tokenised by FTS5."),
+      limit: z.number().int().min(1).max(50).default(10).describe("Maximum rows to return for `list`/`search` (1-50). Default 10."),
+    },
+    annotations: {
+      title: "Architectural decision log",
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: false,
+    },
   },
   async (params) => ({
     content: [{ type: "text" as const, text: await handleDecisionsLog(decRepo, params) }],
   })
 );
 
-server.tool(
+server.registerTool(
   "pitfalls_log",
-  "Track recurring problems and their resolutions.",
   {
-    action: z.string(),
-    project_path: z.string(),
-    title: z.string().default(""),
-    body: z.string().default(""),
-    importance: z.number().default(0.6),
-    limit: z.number().default(10),
-    include_resolved: z.boolean().default(false),
-    pitfall_id: z.string().default(""),
+    title: "Recurring pitfalls log",
+    description: [
+      "Multi-action endpoint for tracking recurring problems and their resolutions. Pick one via `action`:",
+      "  • `store` — record a new pitfall; requires `title` and `body` describing the symptom and the fix.",
+      "  • `list` — list open pitfalls (or all when `include_resolved=true`).",
+      "  • `resolve` — mark a pitfall as resolved; requires `pitfall_id`.",
+      "Use this instead of `memory_store` when something keeps biting and you want a dedicated, queryable log of \"problem → resolution\" pairs. For one-off design choices, use `decisions_log`.",
+      "Side effects: `store` and `resolve` write to the pitfalls table; `list` is read-only.",
+    ].join(" "),
+    inputSchema: {
+      action: z.enum(["store", "list", "resolve"]).describe("Which sub-operation to perform: `store`, `list`, or `resolve`."),
+      project_path: z.string().describe("Absolute project path the pitfall belongs to (or to scope `list`). Required."),
+      title: z.string().default("").describe("Short symptom title (required for `store`). E.g. `\"esbuild fails on M1 when using esm + node-gyp\"`."),
+      body: z.string().default("").describe("Markdown body (required for `store`). Should describe the problem and the resolution / workaround."),
+      importance: z.number().min(0).max(1).default(0.6).describe("Importance score in [0, 1] for `store`. Default 0.6."),
+      limit: z.number().int().min(1).max(50).default(10).describe("Maximum pitfalls to return for `list` (1-50). Default 10."),
+      include_resolved: z.boolean().default(false).describe("For `list`: if true, also include resolved pitfalls. Default false (open only)."),
+      pitfall_id: z.string().default("").describe("Required for `action=\"resolve\"` — the id of the pitfall to mark resolved."),
+    },
+    annotations: {
+      title: "Recurring pitfalls log",
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: false,
+    },
   },
   async (params) => ({
     content: [{ type: "text" as const, text: await handlePitfallsLog(pitRepo, params) }],
   })
 );
 
-server.tool(
+server.registerTool(
   "memory_analytics",
-  "View memory effectiveness: utility rates, token costs, auto-capture stats, prune suggestions.",
   {
-    period: z.enum(["last_24h", "last_7d", "last_30d", "all"]).default("last_7d"),
-    section: z.enum(["all", "injections", "captures", "compression", "memories"]).default("all"),
-    project_path: z.string().default(""),
+    title: "Memory effectiveness analytics",
+    description: [
+      "Report on how the memory system is performing: utility rates of injected memories, token costs of search layers, auto-capture statistics, compression activity, and prune suggestions.",
+      "Use to tune importance thresholds, find dead memories worth pruning, and verify that auto-capture/compression are pulling their weight.",
+      "Read-only. Returns an empty/no-op-style report when analytics are disabled in config.",
+    ].join(" "),
+    inputSchema: {
+      period: z.enum(["last_24h", "last_7d", "last_30d", "all"]).default("last_7d").describe("Time window to summarise. `all` covers the full retention period configured in `analytics.retentionDays`."),
+      section: z.enum(["all", "injections", "captures", "compression", "memories"]).default("all").describe("Which sub-report to render — `injections` (utility), `captures` (auto-capture), `compression`, `memories` (prune suggestions), or `all` (default)."),
+      project_path: z.string().default("").describe("Optional absolute project path to scope the report. Empty string aggregates across all projects."),
+    },
+    annotations: {
+      title: "Memory effectiveness analytics",
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
   },
   async (params) => ({
     content: [{ type: "text" as const, text: await handleMemoryAnalytics(db, params) }],
   })
 );
 
-server.tool(
+server.registerTool(
   "memory_update",
-  "Edit an existing memory in place (title, content, tags, importance, memory_type, pinned).",
   {
-    memory_id: z.string(),
-    title: z.string().optional(),
-    content: z.string().optional(),
-    tags: z.array(z.string()).optional(),
-    importance: z.number().optional(),
-    memory_type: z.string().optional(),
-    pinned: z.boolean().optional(),
-    dedup: z.enum(["strict", "warn", "off"]).optional(),
+    title: "Update a memory in place",
+    description: [
+      "Edit a single memory in place. Only the fields you pass are changed; omitted fields are left untouched.",
+      "Editable fields: `title`, `content`, `tags`, `importance`, `memory_type`, `pinned`. Side effects when the textual content changes: the embedding is re-queued and dedup may run.",
+      "Prefer `memory_store(supersedes_id=...)` instead of in-place edits when the change is significant enough that you'd want history (e.g. a reversed decision). Use this tool for typo fixes, retagging, importance tuning, and similar minor edits.",
+      "Returns a clear `not found` message if the id does not exist.",
+    ].join(" "),
+    inputSchema: {
+      memory_id: z.string().min(1).describe("Id of the memory to update (e.g. `mem_01HXYZ...`)."),
+      title: z.string().optional().describe("New title (single line). Omit to leave unchanged."),
+      content: z.string().optional().describe("New body in markdown. Omit to leave unchanged. When changed, the embedding is re-computed asynchronously."),
+      tags: z.array(z.string()).optional().describe("Replacement tag list. Omit to leave unchanged. Pass `[]` to clear all tags."),
+      importance: z.number().min(0).max(1).optional().describe("New importance score in [0, 1]. Omit to leave unchanged."),
+      memory_type: z.string().optional().describe("New memory_type (e.g. `fact`, `decision`). Omit to leave unchanged."),
+      pinned: z.boolean().optional().describe("New pinned state. Omit to leave unchanged. Equivalent to calling `memory_pin` separately."),
+      dedup: z.enum(["strict", "warn", "off"]).optional().describe("Per-call override for duplicate handling when `content` changes. Mirrors `memory_store.dedup`."),
+    },
+    annotations: {
+      title: "Update a memory in place",
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
   },
   async (params) => ({
     content: [{ type: "text" as const, text: await handleMemoryUpdate(memRepo, params, config, embRepo) }],
   })
 );
 
-server.tool(
+server.registerTool(
   "memory_pin",
-  "Pin or unpin a memory so it survives pruning and ranks higher.",
   {
-    memory_id: z.string(),
-    pinned: z.boolean().default(true),
+    title: "Pin or unpin a memory",
+    description: [
+      "Toggle the pinned flag on a memory. Pinned memories are exempt from automatic pruning and rank higher in search.",
+      "Use sparingly — pinning everything defeats the purpose. Reserve pins for canonical decisions, user preferences, and high-leverage facts you want to survive even long retention windows.",
+      "Idempotent: pinning an already-pinned memory (or unpinning an already-unpinned one) is a no-op.",
+    ].join(" "),
+    inputSchema: {
+      memory_id: z.string().min(1).describe("Id of the memory to pin or unpin."),
+      pinned: z.boolean().default(true).describe("`true` (default) to pin, `false` to unpin."),
+    },
+    annotations: {
+      title: "Pin or unpin a memory",
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
   },
   async (params) => ({
     content: [{ type: "text" as const, text: await handleMemoryPin(memRepo, params) }],
   })
 );
 
-server.tool(
+server.registerTool(
   "memory_compress",
-  "Run the compression pipeline now (cluster similar memories and merge them). Omit project_path to compress all projects.",
   {
-    project_path: z.string().default(""),
+    title: "Run the compression pipeline now",
+    description: [
+      "Run an on-demand compression cycle: cluster similar memories by embedding similarity, merge each cluster into a single canonical memory, and mark the originals as compressed.",
+      "Normally compression runs automatically on the maintenance schedule. Call this tool when you want to force a pass — e.g. right after a bulk import, or to sanity-check compression behaviour.",
+      "Side effects: writes new merged memories and updates the originals' `compressed_into` pointer. Requires `compression.enabled=true` in config; otherwise returns a clear no-op message. May call the configured embeddings + LLM providers.",
+      "Returns a summary of how many clusters were compressed in each project.",
+    ].join(" "),
+    inputSchema: {
+      project_path: z.string().default("").describe("Absolute project path to compress. Empty string (default) compresses every project."),
+    },
+    annotations: {
+      title: "Run the compression pipeline now",
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
   },
   async (params) => ({
     content: [{ type: "text" as const, text: await handleMemoryCompress(db, config, params) }],
   })
 );
 
-server.tool(
+server.registerTool(
   "memory_export",
-  "Export memories/decisions/pitfalls as portable JSON. Omit project_path to export everything.",
   {
-    project_path: z.string().default(""),
+    title: "Export memories as JSON",
+    description: [
+      "Export memories, decisions, and pitfalls as a portable JSON document, suitable for backup, transfer to another machine, or import into another memento-mcp instance via `memory_import`.",
+      "Use before any destructive maintenance (bulk delete, schema migration) so you have a clean restore point. The export includes scope, tags, importance, and supersession links so a round-trip preserves structure.",
+      "Read-only — does not modify any rows. Returns the JSON inline in the tool response.",
+    ].join(" "),
+    inputSchema: {
+      project_path: z.string().default("").describe("Absolute project path to export. Empty string (default) exports memories across all projects."),
+    },
+    annotations: {
+      title: "Export memories as JSON",
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
   },
   async (params) => ({
     content: [{ type: "text" as const, text: await handleMemoryExport(db, params) }],
   })
 );
 
-server.tool(
+server.registerTool(
   "memory_import",
-  "Import memories from a JSON file produced by memory_export. Strategy 'skip' (default) keeps existing rows; 'overwrite' replaces them.",
   {
-    path: z.string(),
-    strategy: z.enum(["skip", "overwrite"]).default("skip"),
+    title: "Import memories from JSON",
+    description: [
+      "Import memories, decisions, and pitfalls from a JSON file previously produced by `memory_export`. The file must be readable from the path given (server-local filesystem, not a URL).",
+      "Conflict handling via `strategy`:",
+      "  • `skip` (default) — keep existing rows when ids collide; only insert missing ones. Safe to re-run.",
+      "  • `overwrite` — replace existing rows on id collisions. Use for authoritative restores.",
+      "Side effects: inserts/updates rows in `memories`, `decisions`, and `pitfalls`. Embeddings are queued asynchronously after import.",
+      "Returns counts of rows inserted, updated, and skipped.",
+    ].join(" "),
+    inputSchema: {
+      path: z.string().min(1).describe("Absolute path on the server's filesystem to a JSON file produced by `memory_export` (e.g. `/tmp/memento-backup.json`)."),
+      strategy: z.enum(["skip", "overwrite"]).default("skip").describe("`skip` (default) preserves existing rows on id collision; `overwrite` replaces them."),
+    },
+    annotations: {
+      title: "Import memories from JSON",
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: false,
+    },
   },
   async (params) => ({
     content: [{ type: "text" as const, text: await handleMemoryImport(db, params) }],
@@ -416,71 +629,113 @@ server.tool(
 
 const edgeTypeEnum = z.enum(["relates_to", "supersedes", "caused_by", "mitigated_by", "references", "implements"]);
 
-server.tool(
+server.registerTool(
   "memory_link",
-  [
-    "Create a typed edge between two memories. Edge types: relates_to | supersedes | caused_by | mitigated_by | references | implements.",
-    "Use memory_search first to find the ids, then memory_link to connect them.",
-    "Optional weight (0-1) signals edge strength (default 1.0).",
-    "Re-linking an existing (from,to,type) triple updates its weight.",
-  ].join(" "),
   {
-    from_id: z.string(),
-    to_id: z.string(),
-    edge_type: edgeTypeEnum,
-    weight: z.number().min(0).max(1).default(1.0),
+    title: "Link two memories with a typed edge",
+    description: [
+      "Create a typed directed edge from one memory to another in the knowledge graph. Use the resulting graph to map dependencies, supersession chains, cause/effect, and references.",
+      "Supported edge types: `relates_to`, `supersedes`, `caused_by`, `mitigated_by`, `references`, `implements`.",
+      "Workflow: call `memory_search` (or `memory_list`) first to find the two ids, then `memory_link` to connect them. Re-linking the same `(from_id, to_id, edge_type)` triple updates its weight rather than creating a duplicate.",
+      "Side effects: writes a row to the edges table.",
+    ].join(" "),
+    inputSchema: {
+      from_id: z.string().min(1).describe("Source memory id (the edge points outward from this memory)."),
+      to_id: z.string().min(1).describe("Target memory id."),
+      edge_type: edgeTypeEnum.describe("Relationship type. `supersedes` is the same notion used by `memory_store.supersedes_id`."),
+      weight: z.number().min(0).max(1).default(1.0).describe("Edge strength in [0, 1]. Default 1.0. Lower values can be used to weaken weak \"relates_to\" hints."),
+    },
+    annotations: {
+      title: "Link two memories with a typed edge",
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
   },
   async (params) => ({
     content: [{ type: "text" as const, text: await handleMemoryLink(memRepo, edgesRepo, params) }],
   })
 );
 
-server.tool(
+server.registerTool(
   "memory_unlink",
-  "Remove a typed edge between two memories. Provide the same from_id, to_id, and edge_type used when the edge was created.",
   {
-    from_id: z.string(),
-    to_id: z.string(),
-    edge_type: edgeTypeEnum,
+    title: "Remove an edge between two memories",
+    description: [
+      "Remove a previously created edge from the knowledge graph. You must pass the exact `(from_id, to_id, edge_type)` triple used when the edge was created — `memory_unlink` does not remove arbitrary or wildcard edges.",
+      "Idempotent: removing a non-existent edge returns a clear message and is a no-op.",
+      "Use this to retract incorrect links; for retracting an entire memory, prefer `memory_delete` (which leaves the audit trail intact).",
+    ].join(" "),
+    inputSchema: {
+      from_id: z.string().min(1).describe("Source memory id of the edge to remove."),
+      to_id: z.string().min(1).describe("Target memory id of the edge to remove."),
+      edge_type: edgeTypeEnum.describe("Edge type that was used when the edge was created. Must match exactly."),
+    },
+    annotations: {
+      title: "Remove an edge between two memories",
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
   },
   async (params) => ({
     content: [{ type: "text" as const, text: await handleMemoryUnlink(edgesRepo, params) }],
   })
 );
 
-server.tool(
+server.registerTool(
   "memory_graph",
-  [
-    "Explore the knowledge graph around a memory (BFS up to depth hops).",
-    "Returns neighbour nodes with typed edges. Edge types: relates_to | supersedes | caused_by | mitigated_by | references | implements.",
-    "Chain: memory_search → memory_graph to map related concepts.",
-    "direction='out' follows outgoing edges only; 'in' follows incoming; 'both' (default) follows all.",
-    "Depth 0 returns just the root node; max depth is 5.",
-  ].join(" "),
   {
-    id: z.string(),
-    depth: z.number().int().min(0).max(5).default(2),
-    edge_types: z.array(edgeTypeEnum).optional(),
-    direction: z.enum(["out", "in", "both"]).default("both"),
+    title: "Explore the knowledge graph around a memory",
+    description: [
+      "Breadth-first walk of the knowledge graph rooted at one memory id. Returns the root plus its neighbour nodes (titles + ids) and the typed edges between them.",
+      "Use to map related concepts, surface supersession chains, or visualise the cluster around a decision. Chain pattern: `memory_search` → `memory_graph` to expand the most relevant hit.",
+      "Direction control: `out` follows outgoing edges only, `in` follows incoming, `both` (default) follows all.",
+      "Depth 0 returns just the root node; max depth is 5 to keep results bounded. Read-only.",
+    ].join(" "),
+    inputSchema: {
+      id: z.string().min(1).describe("Memory id to use as the root of the BFS walk."),
+      depth: z.number().int().min(0).max(5).default(2).describe("How many hops to traverse from the root (0-5). Default 2."),
+      edge_types: z.array(edgeTypeEnum).optional().describe("Optional whitelist of edge types to follow. Omit to follow all types."),
+      direction: z.enum(["out", "in", "both"]).default("both").describe("`out` follows outgoing edges only, `in` incoming only, `both` (default) follows all."),
+    },
+    annotations: {
+      title: "Explore the knowledge graph around a memory",
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
   },
   async (params) => ({
     content: [{ type: "text" as const, text: await handleMemoryGraph(memRepo, edgesRepo, params) }],
   })
 );
 
-server.tool(
+server.registerTool(
   "memory_path",
-  [
-    "Find the shortest path between two memories in the knowledge graph.",
-    "Returns the chain of memory ids and edge types connecting from_id to to_id.",
-    "Chain: memory_search → memory_path to trace cause-effect or dependency chains.",
-    "max_hops limits BFS depth (default 4, max 10).",
-  ].join(" "),
   {
-    from_id: z.string(),
-    to_id: z.string(),
-    max_hops: z.number().int().min(1).max(10).default(4),
-    edge_types: z.array(edgeTypeEnum).optional(),
+    title: "Shortest path between two memories",
+    description: [
+      "Find the shortest path (smallest number of hops) between two memories in the knowledge graph using BFS. Returns the chain of memory ids and the edge types that connect them, or a clear `no path` message.",
+      "Use to trace cause-effect chains, supersession history, or dependency lineage. Chain pattern: `memory_search` → `memory_path` once you know both endpoints.",
+      "Read-only.",
+    ].join(" "),
+    inputSchema: {
+      from_id: z.string().min(1).describe("Starting memory id."),
+      to_id: z.string().min(1).describe("Destination memory id."),
+      max_hops: z.number().int().min(1).max(10).default(4).describe("Maximum BFS depth (1-10). Default 4. Returns `no path` if the destination is further than `max_hops` from the start."),
+      edge_types: z.array(edgeTypeEnum).optional().describe("Optional whitelist of edge types to follow. Omit to allow all types."),
+    },
+    annotations: {
+      title: "Shortest path between two memories",
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
   },
   async (params) => ({
     content: [{ type: "text" as const, text: await handleMemoryPath(memRepo, edgesRepo, params) }],

--- a/src/tools/memory-graph.ts
+++ b/src/tools/memory-graph.ts
@@ -1,6 +1,6 @@
 // src/tools/memory-graph.ts
 import type { MemoriesRepo } from "../db/memories.js";
-import type { EdgesRepo, EdgeRow, EdgeType } from "../db/edges.js";
+import type { EdgesRepo, EdgeType } from "../db/edges.js";
 import { estimateTokensV2 } from "../engine/token-estimator.js";
 
 export interface MemoryGraphParams {
@@ -10,17 +10,33 @@ export interface MemoryGraphParams {
   direction?: "out" | "in" | "both";
 }
 
-export async function handleMemoryGraph(
+/** Structured payload for memory_graph's outputSchema. */
+export type MemoryGraphResult = {
+  found: boolean;
+  root?: { id: string; title: string; memory_type: string };
+  edges: Array<{
+    direction: "out" | "in";
+    edge_type: EdgeType;
+    weight?: number;
+    other: { id: string; title: string; memory_type: string };
+    token_cost: number;
+  }>;
+};
+
+export async function walkMemoryGraph(
   memRepo: MemoriesRepo,
   edgesRepo: EdgesRepo,
-  params: MemoryGraphParams
-): Promise<string> {
+  params: MemoryGraphParams,
+): Promise<{ text: string; structured: MemoryGraphResult }> {
   const depth = params.depth ?? 2;
   const direction = params.direction ?? "both";
 
   const root = memRepo.getById(params.id);
   if (!root) {
-    return `Memory ${params.id} not found.`;
+    return {
+      text: `Memory ${params.id} not found.`,
+      structured: { found: false, edges: [] },
+    };
   }
 
   const { edges } = edgesRepo.subgraph(params.id, depth, params.edge_types, direction);
@@ -28,10 +44,16 @@ export async function handleMemoryGraph(
   const header = `Memory: "${root.title}" (${root.memory_type})`;
 
   if (edges.length === 0) {
-    return header;
+    return {
+      text: header,
+      structured: {
+        found: true,
+        root: { id: String(root.id), title: String(root.title), memory_type: String(root.memory_type) },
+        edges: [],
+      },
+    };
   }
 
-  // Sort edges by edge_type then by the other node id
   const sorted = [...edges].sort((a, b) => {
     if (a.edge_type !== b.edge_type) return a.edge_type.localeCompare(b.edge_type);
     const aOther = a.from_id === params.id ? a.to_id : a.from_id;
@@ -40,6 +62,8 @@ export async function handleMemoryGraph(
   });
 
   const lines: string[] = [header];
+  const structuredEdges: MemoryGraphResult["edges"] = [];
+
   for (const edge of sorted) {
     const otherId = edge.from_id === params.id ? edge.to_id : edge.from_id;
     const isOutgoing = edge.from_id === params.id;
@@ -52,7 +76,32 @@ export async function handleMemoryGraph(
     const lineContent = `  ${dirMarker} "${otherTitle}" (${otherType})`;
     const tokenCost = estimateTokensV2(lineContent);
     lines.push(`${lineContent} [${tokenCost}t]`);
+
+    structuredEdges.push({
+      direction: isOutgoing ? "out" : "in",
+      edge_type: edge.edge_type,
+      ...(typeof (edge as any).weight === "number" ? { weight: Number((edge as any).weight) } : {}),
+      other: { id: String(otherId), title: String(otherTitle), memory_type: String(otherType) },
+      token_cost: tokenCost,
+    });
   }
 
-  return lines.join("\n");
+  return {
+    text: lines.join("\n"),
+    structured: {
+      found: true,
+      root: { id: String(root.id), title: String(root.title), memory_type: String(root.memory_type) },
+      edges: structuredEdges,
+    },
+  };
+}
+
+/** Backward-compatible wrapper returning only the rendered text. */
+export async function handleMemoryGraph(
+  memRepo: MemoriesRepo,
+  edgesRepo: EdgesRepo,
+  params: MemoryGraphParams,
+): Promise<string> {
+  const { text } = await walkMemoryGraph(memRepo, edgesRepo, params);
+  return text;
 }

--- a/src/tools/memory-list.ts
+++ b/src/tools/memory-list.ts
@@ -22,19 +22,34 @@ function vaultNoteToEntry(note: VaultNoteRow): SourceIndexEntry {
   };
 }
 
-export async function handleMemoryList(
+/** Structured payload for memory_list's outputSchema. */
+export type MemoryListResult = {
+  detail: "index" | "summary" | "full";
+  count: number;
+  memories: Array<{
+    id: string;
+    title: string;
+    source: "sqlite" | "file";
+    memory_type?: string;
+    importance?: number;
+    pinned?: boolean;
+    body?: string;
+  }>;
+  vault_results: Array<{ id: string; title: string; relativePath: string; kind?: string }>;
+};
+
+export async function listMemories(
   repo: MemoriesRepo,
   config: Config,
   params: {
     project_path?: string; memory_type?: string; scope?: string;
     pinned_only?: boolean; limit?: number; detail?: "index" | "summary" | "full";
     include_file_memories?: boolean;
-    // vault-specific filters
     vault_kind?: string; vault_folder?: string;
   },
   db?: Database.Database,
-): Promise<string> {
-  const detail = params.detail ?? config.search.defaultDetail;
+): Promise<{ text: string; structured: MemoryListResult }> {
+  const detail = (params.detail ?? config.search.defaultDetail) as "index" | "summary" | "full";
   const results: any[] = repo.list({
     projectPath: params.project_path, memoryType: params.memory_type,
     scope: params.scope, pinnedOnly: params.pinned_only, limit: params.limit,
@@ -56,6 +71,8 @@ export async function handleMemoryList(
   else sqliteOutput = formatFull(results, config.search.bodyPreviewChars);
 
   // Vault listing
+  let vaultEntries: SourceIndexEntry[] = [];
+  let vaultOutput = "";
   if (db && config.vault.enabled && config.vault.path) {
     let q = "SELECT * FROM vault_notes WHERE vault_path = ? AND routable = 1 AND blocked = 0 AND orphan = 0";
     const bindings: unknown[] = [config.vault.path];
@@ -68,16 +85,54 @@ export async function handleMemoryList(
     const vaultRows = db.prepare(q).all(...bindings) as VaultNoteRow[];
 
     if (vaultRows.length > 0) {
-      const entries = vaultRows.map(vaultNoteToEntry);
-      const vaultOutput = detail === "index"
-        ? formatVaultIndex(entries)
-        : entries.map(formatVaultEntry).join("\n\n");
-
-      return sqliteOutput && sqliteOutput !== "No results found."
-        ? sqliteOutput + "\n\n" + vaultOutput
-        : vaultOutput;
+      vaultEntries = vaultRows.map(vaultNoteToEntry);
+      vaultOutput = detail === "index"
+        ? formatVaultIndex(vaultEntries)
+        : vaultEntries.map(formatVaultEntry).join("\n\n");
     }
   }
 
-  return sqliteOutput;
+  const text = vaultOutput
+    ? (sqliteOutput && sqliteOutput !== "No results found."
+        ? sqliteOutput + "\n\n" + vaultOutput
+        : vaultOutput)
+    : sqliteOutput;
+
+  const structured: MemoryListResult = {
+    detail,
+    count: results.length,
+    memories: results.map(r => ({
+      id: String(r.id),
+      title: String(r.title ?? ""),
+      source: r.source as "sqlite" | "file",
+      ...(r.memory_type ? { memory_type: String(r.memory_type) } : {}),
+      ...(r.importance_score !== undefined ? { importance: Number(r.importance_score) } : {}),
+      ...(r.pinned !== undefined ? { pinned: Boolean(r.pinned) } : {}),
+      ...(detail !== "index" && r.body ? { body: String(r.body) } : {}),
+    })),
+    vault_results: vaultEntries.map(v => ({
+      id: String(v.id),
+      title: String(v.title),
+      relativePath: String(v.path ?? ""),
+      ...(v.kind ? { kind: String(v.kind) } : {}),
+    })),
+  };
+
+  return { text, structured };
+}
+
+/** Backward-compatible wrapper returning only the rendered text. */
+export async function handleMemoryList(
+  repo: MemoriesRepo,
+  config: Config,
+  params: {
+    project_path?: string; memory_type?: string; scope?: string;
+    pinned_only?: boolean; limit?: number; detail?: "index" | "summary" | "full";
+    include_file_memories?: boolean;
+    vault_kind?: string; vault_folder?: string;
+  },
+  db?: Database.Database,
+): Promise<string> {
+  const { text } = await listMemories(repo, config, params, db);
+  return text;
 }

--- a/src/tools/memory-path.ts
+++ b/src/tools/memory-path.ts
@@ -9,49 +9,95 @@ export interface MemoryPathParams {
   edge_types?: EdgeType[];
 }
 
-export async function handleMemoryPath(
+/** Structured payload for memory_path's outputSchema. */
+export type MemoryPathResult = {
+  found: boolean;
+  hops: number;
+  path: Array<{ id: string; title: string; edge_type_to_next?: EdgeType }>;
+  message?: string;
+};
+
+export async function findMemoryPath(
   memRepo: MemoriesRepo,
   edgesRepo: EdgesRepo,
-  params: MemoryPathParams
-): Promise<string> {
+  params: MemoryPathParams,
+): Promise<{ text: string; structured: MemoryPathResult }> {
   const maxHops = params.max_hops ?? 4;
 
   const path = edgesRepo.shortestPath(params.from_id, params.to_id, maxHops, params.edge_types);
   if (!path) {
-    return `No path from ${params.from_id} to ${params.to_id} within ${maxHops} hops`;
+    const message = `No path from ${params.from_id} to ${params.to_id} within ${maxHops} hops`;
+    return {
+      text: message,
+      structured: { found: false, hops: 0, path: [], message },
+    };
   }
 
   if (path.length === 1) {
     const mem = memRepo.getById(path[0]);
     const title = mem ? mem.title : path[0];
-    return `${path[0]} "${title}"`;
+    return {
+      text: `${path[0]} "${title}"`,
+      structured: {
+        found: true,
+        hops: 0,
+        path: [{ id: String(path[0]), title: String(title) }],
+      },
+    };
   }
 
   const parts: string[] = [];
+  const structuredNodes: MemoryPathResult["path"] = [];
+
   for (let i = 0; i < path.length; i++) {
     const nodeId = path[i];
     const mem = memRepo.getById(nodeId);
     const title = mem ? mem.title : nodeId;
     parts.push(`${nodeId} "${title}"`);
 
+    let edgeTypeToNext: EdgeType | undefined;
     if (i < path.length - 1) {
       const nextId = path[i + 1];
-      // Find edge type between nodeId and nextId
       const outEdges = edgesRepo.outgoing(nodeId, params.edge_types);
       const matchingOut = outEdges.find(e => e.to_id === nextId);
       if (matchingOut) {
         parts.push(`→ ${matchingOut.edge_type} →`);
+        edgeTypeToNext = matchingOut.edge_type;
       } else {
         const inEdges = edgesRepo.incoming(nodeId, params.edge_types);
         const matchingIn = inEdges.find(e => e.from_id === nextId);
         if (matchingIn) {
           parts.push(`→ ${matchingIn.edge_type} →`);
+          edgeTypeToNext = matchingIn.edge_type;
         } else {
           parts.push(`→`);
         }
       }
     }
+
+    structuredNodes.push({
+      id: String(nodeId),
+      title: String(title),
+      ...(edgeTypeToNext ? { edge_type_to_next: edgeTypeToNext } : {}),
+    });
   }
 
-  return parts.join(" ");
+  return {
+    text: parts.join(" "),
+    structured: {
+      found: true,
+      hops: path.length - 1,
+      path: structuredNodes,
+    },
+  };
+}
+
+/** Backward-compatible wrapper returning only the rendered text. */
+export async function handleMemoryPath(
+  memRepo: MemoriesRepo,
+  edgesRepo: EdgesRepo,
+  params: MemoryPathParams,
+): Promise<string> {
+  const { text } = await findMemoryPath(memRepo, edgesRepo, params);
+  return text;
 }

--- a/src/tools/memory-search.ts
+++ b/src/tools/memory-search.ts
@@ -8,7 +8,29 @@ import { formatIndex, formatFull, formatSummary, formatVaultEntry, formatVaultIn
 import { estimateTokensV2 } from "../engine/token-estimator.js";
 import { searchVault } from "../engine/vault-router.js";
 
-export async function handleMemorySearch(
+/** Structured payload for the memory_search tool's outputSchema. */
+export type MemorySearchResult = {
+  query: string;
+  detail: "index" | "summary" | "full";
+  count: number;
+  results: Array<{
+    id: string;
+    title: string;
+    score: number;
+    source: "sqlite" | "file";
+    memory_type?: string;
+    body?: string;
+  }>;
+  vault_results: Array<{ relativePath: string; title?: string }>;
+  total_tokens: number;
+};
+
+/**
+ * Run a memory search and produce both a human-readable text rendering and a
+ * machine-readable structured payload. The text and structured shape are
+ * computed from the same in-memory result set so they can never disagree.
+ */
+export async function searchMemories(
   repo: MemoriesRepo,
   config: Config,
   params: {
@@ -17,7 +39,7 @@ export async function handleMemorySearch(
   },
   db?: Database.Database,
   analyticsTracker?: AnalyticsTracker,
-): Promise<string> {
+): Promise<{ text: string; structured: MemorySearchResult }> {
   const limit = params.limit ?? config.search.maxResults;
   const detail = params.detail ?? config.search.defaultDetail;
   const sqliteResults: any[] = [];
@@ -65,19 +87,57 @@ export async function handleMemorySearch(
       : vaultSection;
   }
 
-  const finalOutput = output || "No results found.";
+  const text = output || "No results found.";
+  const total_tokens = estimateTokensV2(text);
 
   // Emit analytics event for search layer used
   if (analyticsTracker) {
-    const totalTokens = estimateTokensV2(finalOutput);
     const sessionId = process.env.CLAUDE_SESSION_ID || "unknown";
     analyticsTracker.track({
       event_type: "search_layer_used",
       session_id: sessionId,
-      event_data: JSON.stringify({ detail: detail || "full", results: limitedSqlite.length, total_tokens: totalTokens }),
-      tokens_cost: totalTokens,
+      event_data: JSON.stringify({ detail: detail || "full", results: limitedSqlite.length, total_tokens }),
+      tokens_cost: total_tokens,
     });
   }
 
-  return finalOutput;
+  const structured: MemorySearchResult = {
+    query: params.query,
+    detail: (detail ?? "index") as "index" | "summary" | "full",
+    count: limitedSqlite.length,
+    results: limitedSqlite.map(r => ({
+      id: String(r.id),
+      title: String(r.title ?? ""),
+      score: Number(r.score ?? 0),
+      source: r.source as "sqlite" | "file",
+      ...(r.memory_type ? { memory_type: String(r.memory_type) } : {}),
+      ...(detail !== "index" && r.body ? { body: String(r.body) } : {}),
+    })),
+    vault_results: vaultEntries.map(v => ({
+      relativePath: String((v as any).relativePath ?? (v as any).path ?? ""),
+      ...(((v as any).title) ? { title: String((v as any).title) } : {}),
+    })),
+    total_tokens,
+  };
+
+  return { text, structured };
+}
+
+/**
+ * Backward-compatible wrapper — many tests and call sites import this and
+ * expect a string. Internally it just delegates to `searchMemories` and
+ * returns the rendered text.
+ */
+export async function handleMemorySearch(
+  repo: MemoriesRepo,
+  config: Config,
+  params: {
+    query: string; project_path?: string; memory_type?: string;
+    limit?: number; detail?: "index" | "summary" | "full"; include_file_memories?: boolean;
+  },
+  db?: Database.Database,
+  analyticsTracker?: AnalyticsTracker,
+): Promise<string> {
+  const { text } = await searchMemories(repo, config, params, db, analyticsTracker);
+  return text;
 }

--- a/tests/integration/mcp-server-smoke.test.ts
+++ b/tests/integration/mcp-server-smoke.test.ts
@@ -6,7 +6,6 @@
 // This is the most critical test in the suite: it verifies the package's
 // primary entry point works as an MCP server.
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
-import { spawnSync } from "node:child_process";
 import { existsSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
@@ -21,25 +20,10 @@ describe("MCP server — protocol smoke test", () => {
   let transport: StdioClientTransport | null = null;
 
   beforeAll(async () => {
-    // R8: build the binary as a prerequisite.
-    const buildResult = spawnSync(
-      "./node_modules/.bin/tsup",
-      [
-        "src/index.ts",
-        "src/cli/main.ts",
-        "src/hooks/search-context.ts",
-        "src/hooks/session-context.ts",
-        "src/hooks/auto-capture-bin.ts",
-        "src/hooks/session-summarize-bin.ts",
-        "--format", "esm", "--dts", "--clean",
-      ],
-      { cwd: process.cwd(), encoding: "utf-8", timeout: 120_000 },
-    );
-    if (buildResult.status !== 0) {
-      throw new Error(`Build prerequisite failed.\nstderr: ${buildResult.stderr}\nstdout: ${buildResult.stdout}`);
-    }
+    // The MCP server binary is built once by tests/setup/build-once.ts
+    // (registered as vitest globalSetup), so we just check the artifact exists.
     if (!existsSync(distEntry)) {
-      throw new Error(`Built MCP server missing at ${distEntry}`);
+      throw new Error(`Built MCP server missing at ${distEntry} (expected globalSetup to produce it).`);
     }
 
     // Sandbox HOME so the server resolves its DB/config under a tempdir

--- a/tests/setup/build-once.ts
+++ b/tests/setup/build-once.ts
@@ -1,0 +1,37 @@
+// tests/setup/build-once.ts
+//
+// Vitest globalSetup: builds the MCP server bundle once before any spec runs.
+// Integration specs (mcp-server-smoke, tool-descriptions) spawn `dist/index.js`
+// directly. Without this single-shot build, each spec would race the others to
+// rebuild + `--clean` the same directory.
+
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+export default function build(): void {
+  const distEntry = join(process.cwd(), "dist/index.js");
+
+  const result = spawnSync(
+    "./node_modules/.bin/tsup",
+    [
+      "src/index.ts",
+      "src/cli/main.ts",
+      "src/hooks/search-context.ts",
+      "src/hooks/session-context.ts",
+      "src/hooks/auto-capture-bin.ts",
+      "src/hooks/session-summarize-bin.ts",
+      "--format", "esm", "--dts", "--clean",
+    ],
+    { cwd: process.cwd(), encoding: "utf-8", timeout: 120_000 },
+  );
+
+  if (result.status !== 0) {
+    throw new Error(
+      `globalSetup build failed.\nstderr: ${result.stderr}\nstdout: ${result.stdout}`,
+    );
+  }
+  if (!existsSync(distEntry)) {
+    throw new Error(`globalSetup completed but ${distEntry} is missing.`);
+  }
+}

--- a/tests/tools/structured-payloads.test.ts
+++ b/tests/tools/structured-payloads.test.ts
@@ -1,0 +1,153 @@
+// tests/tools/structured-payloads.test.ts
+//
+// Unit tests for the structured ({ text, structured }) variants of the four
+// MCP tools that expose rich outputSchemas: memory_search, memory_list,
+// memory_graph, memory_path.
+//
+// We assert that:
+//   • the structured payload mirrors the rendered text (no drift),
+//   • required fields are populated,
+//   • shapes match what their tool-level outputSchema declares.
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomUUID } from "node:crypto";
+
+import { createDatabase } from "../../src/db/database.js";
+import { MemoriesRepo } from "../../src/db/memories.js";
+import { EdgesRepo } from "../../src/db/edges.js";
+import { searchMemories } from "../../src/tools/memory-search.js";
+import { listMemories } from "../../src/tools/memory-list.js";
+import { walkMemoryGraph } from "../../src/tools/memory-graph.js";
+import { findMemoryPath } from "../../src/tools/memory-path.js";
+import { DEFAULT_CONFIG } from "../../src/lib/config.js";
+
+describe("structured tool payloads", () => {
+  let db: ReturnType<typeof createDatabase>;
+  let memRepo: MemoriesRepo;
+  let edgesRepo: EdgesRepo;
+  const dbPath = join(tmpdir(), `memento-structured-${process.pid}-${randomUUID()}.sqlite`);
+
+  beforeEach(() => {
+    db = createDatabase(dbPath);
+    memRepo = new MemoriesRepo(db);
+    edgesRepo = new EdgesRepo(db);
+  });
+
+  afterEach(() => {
+    db.close();
+    rmSync(dbPath, { force: true });
+  });
+
+  function store(title: string, body = `body of ${title}`): string {
+    return memRepo.store({ title, body, memoryType: "fact", scope: "global" });
+  }
+
+  describe("searchMemories", () => {
+    it("returns parallel text + structured payloads describing the same hits", async () => {
+      const aId = store("Alpha topic", "alpha alpha alpha");
+      store("Beta topic", "beta beta");
+
+      const { text, structured } = await searchMemories(memRepo, DEFAULT_CONFIG, {
+        query: "alpha", detail: "summary",
+      });
+
+      expect(text).toContain("Alpha topic");
+      expect(structured.query).toBe("alpha");
+      expect(structured.detail).toBe("summary");
+      expect(structured.count).toBeGreaterThan(0);
+      expect(structured.results.some(r => r.id === aId && r.title === "Alpha topic")).toBe(true);
+      expect(structured.results.every(r => typeof r.score === "number")).toBe(true);
+      expect(structured.results.every(r => r.source === "sqlite" || r.source === "file")).toBe(true);
+      expect(structured.total_tokens).toBeGreaterThan(0);
+      // Vault is disabled in DEFAULT_CONFIG → empty array, not undefined.
+      expect(Array.isArray(structured.vault_results)).toBe(true);
+    });
+
+    it("renders empty result sets consistently in both shapes", async () => {
+      const { text, structured } = await searchMemories(memRepo, DEFAULT_CONFIG, {
+        query: "nooooomatch-xyzzy",
+      });
+      expect(text).toBe("No results found.");
+      expect(structured.count).toBe(0);
+      expect(structured.results).toEqual([]);
+    });
+  });
+
+  describe("listMemories", () => {
+    it("returns count + memories + empty vault_results when vault disabled", async () => {
+      const id = store("Listed memory");
+
+      const { text, structured } = await listMemories(memRepo, DEFAULT_CONFIG, { detail: "index" });
+
+      expect(text).toContain("Listed memory");
+      expect(structured.detail).toBe("index");
+      expect(structured.count).toBeGreaterThan(0);
+      expect(structured.memories.some(m => m.id === id && m.title === "Listed memory")).toBe(true);
+      expect(structured.vault_results).toEqual([]);
+    });
+  });
+
+  describe("walkMemoryGraph", () => {
+    it("returns found=false with empty edges when the root is missing", async () => {
+      const { text, structured } = await walkMemoryGraph(memRepo, edgesRepo, { id: "no-such-id" });
+      expect(text).toContain("not found");
+      expect(structured.found).toBe(false);
+      expect(structured.edges).toEqual([]);
+      expect(structured.root).toBeUndefined();
+    });
+
+    it("returns found=true with edges when neighbours exist", async () => {
+      const a = store("A");
+      const b = store("B");
+      edgesRepo.link(a, b, "relates_to", 1.0);
+
+      const { text, structured } = await walkMemoryGraph(memRepo, edgesRepo, { id: a, depth: 1 });
+
+      expect(text).toContain("A");
+      expect(text).toContain("relates_to");
+      expect(structured.found).toBe(true);
+      expect(structured.root?.id).toBe(a);
+      expect(structured.edges.length).toBe(1);
+      expect(structured.edges[0].direction).toBe("out");
+      expect(structured.edges[0].edge_type).toBe("relates_to");
+      expect(structured.edges[0].other.id).toBe(b);
+    });
+  });
+
+  describe("findMemoryPath", () => {
+    it("returns found=false with a message when there is no path", async () => {
+      const a = store("A");
+      const b = store("B");
+
+      const { text, structured } = await findMemoryPath(memRepo, edgesRepo, { from_id: a, to_id: b });
+
+      expect(text).toContain("No path");
+      expect(structured.found).toBe(false);
+      expect(structured.hops).toBe(0);
+      expect(structured.path).toEqual([]);
+      expect(structured.message).toBeTruthy();
+    });
+
+    it("returns hops + path with edge_type_to_next chained between nodes", async () => {
+      const a = store("A");
+      const b = store("B");
+      const c = store("C");
+      edgesRepo.link(a, b, "relates_to", 1.0);
+      edgesRepo.link(b, c, "caused_by", 1.0);
+
+      const { text, structured } = await findMemoryPath(memRepo, edgesRepo, { from_id: a, to_id: c });
+
+      expect(text).toContain("A");
+      expect(text).toContain("C");
+      expect(structured.found).toBe(true);
+      expect(structured.hops).toBe(2);
+      expect(structured.path.map(n => n.id)).toEqual([a, b, c]);
+      expect(structured.path[0].edge_type_to_next).toBe("relates_to");
+      expect(structured.path[1].edge_type_to_next).toBe("caused_by");
+      expect(structured.path[2].edge_type_to_next).toBeUndefined();
+    });
+  });
+});

--- a/tests/tools/tool-descriptions.test.ts
+++ b/tests/tools/tool-descriptions.test.ts
@@ -1,32 +1,185 @@
-import { describe, it, expect } from "vitest";
+// tests/tools/tool-descriptions.test.ts
+//
+// TDQS guard rails (Glama Tool Definition Quality Score).
+// We boot the actual MCP server, list its tools, and assert that every tool
+// definition meets the bar across the six TDQS dimensions:
+//   • Purpose Clarity         — description present and substantive
+//   • Usage Guidelines        — description hints at *when* to use the tool
+//   • Behavioral Transparency — annotations are populated (read-only/destructive/idempotent/openWorld)
+//   • Parameter Semantics     — every input parameter has its own description
+//   • Conciseness & Structure — descriptions stay under a sane upper bound
+//   • Contextual Completeness — naming conventions are consistent across the surface
+//
+// These tests are deliberately schema-level (they introspect the MCP listTools
+// response) so they protect every future tool addition automatically.
 
-// We test the descriptions by checking character count of each tool's description.
-// The goal is: every description < 100 chars. v1 has descriptions up to 200+ chars.
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { spawnSync } from "node:child_process";
+import { existsSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomUUID } from "node:crypto";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 
-describe("tool description optimization", () => {
-  // Import the raw descriptions from index.ts by reading the file
-  // Actually, since descriptions are inline in server.tool() calls,
-  // we test by running a snapshot of the expected descriptions.
-
-  const V2_DESCRIPTIONS: Record<string, string> = {
-    memory_store: "Persist a fact, decision, or pattern. Auto-indexed for search.",
-    memory_search: "Search memories by query. Returns ranked results.",
-    memory_get: "Get full content of a memory by ID.",
-    memory_list: "List memories with optional filters.",
-    memory_delete: "Soft-delete a memory by ID.",
-    decisions_log: "Store, list, or search architectural decisions.",
-    pitfalls_log: "Track recurring problems and their resolutions.",
+type Tool = {
+  name: string;
+  title?: string;
+  description?: string;
+  inputSchema?: {
+    type?: string;
+    properties?: Record<string, { description?: string; type?: string | string[] }>;
+    required?: string[];
   };
+  annotations?: {
+    title?: string;
+    readOnlyHint?: boolean;
+    destructiveHint?: boolean;
+    idempotentHint?: boolean;
+    openWorldHint?: boolean;
+  };
+};
 
-  for (const [tool, desc] of Object.entries(V2_DESCRIPTIONS)) {
-    it(`${tool} description is under 80 chars`, () => {
-      expect(desc.length).toBeLessThanOrEqual(80);
-    });
+const distEntry = join(process.cwd(), "dist/index.js");
+let client: Client | null = null;
+let transport: StdioClientTransport | null = null;
+let dbPath = "";
+let tools: Tool[] = [];
+
+beforeAll(async () => {
+  const buildResult = spawnSync(
+    "./node_modules/.bin/tsup",
+    [
+      "src/index.ts",
+      "src/cli/main.ts",
+      "src/hooks/search-context.ts",
+      "src/hooks/session-context.ts",
+      "src/hooks/auto-capture-bin.ts",
+      "src/hooks/session-summarize-bin.ts",
+      "--format", "esm", "--dts", "--clean",
+    ],
+    { cwd: process.cwd(), encoding: "utf-8", timeout: 120_000 },
+  );
+  if (buildResult.status !== 0) {
+    throw new Error(`Build prerequisite failed.\nstderr: ${buildResult.stderr}\nstdout: ${buildResult.stdout}`);
+  }
+  if (!existsSync(distEntry)) {
+    throw new Error(`Built MCP server missing at ${distEntry}`);
   }
 
-  it("total description tokens across all tools is under 200", () => {
-    const totalChars = Object.values(V2_DESCRIPTIONS).join("").length;
-    const estimatedTokens = Math.ceil(totalChars / 4);
-    expect(estimatedTokens).toBeLessThan(200);
+  const fakeHome = join(tmpdir(), `mcp-tdqs-home-${process.pid}-${randomUUID()}`);
+  dbPath = fakeHome;
+
+  transport = new StdioClientTransport({
+    command: process.execPath,
+    args: [distEntry],
+    env: { ...process.env, HOME: fakeHome, APPDATA: fakeHome },
+  });
+  client = new Client({ name: "tdqs-test-client", version: "0.0.0" });
+  await client.connect(transport);
+
+  const list = await client.listTools();
+  tools = list.tools as unknown as Tool[];
+}, 180_000);
+
+afterAll(async () => {
+  try { await client?.close(); } catch { /* ignore */ }
+  try { await transport?.close(); } catch { /* ignore */ }
+  if (dbPath) rmSync(dbPath, { recursive: true, force: true });
+});
+
+describe("TDQS — Purpose Clarity", () => {
+  it("every tool has a non-empty description of at least 60 chars", () => {
+    for (const t of tools) {
+      expect(t.description, `${t.name}: missing description`).toBeTruthy();
+      expect(t.description!.length, `${t.name}: description too short`).toBeGreaterThanOrEqual(60);
+    }
+  });
+
+  it("every tool has a human-friendly title annotation", () => {
+    for (const t of tools) {
+      const title = t.annotations?.title ?? t.title;
+      expect(title, `${t.name}: missing title`).toBeTruthy();
+      expect(title!.length, `${t.name}: title too short`).toBeGreaterThanOrEqual(3);
+    }
+  });
+});
+
+describe("TDQS — Usage Guidelines", () => {
+  // A description that mentions when/why/use/prefer/instead is signalling guidance,
+  // not just a restatement of the name.
+  const GUIDANCE_HINTS = ["use", "when", "prefer", "instead", "workflow", "before", "after"];
+
+  it("every tool description hints at when/how to use it", () => {
+    for (const t of tools) {
+      const lower = (t.description ?? "").toLowerCase();
+      const hit = GUIDANCE_HINTS.some(h => lower.includes(h));
+      expect(hit, `${t.name}: description lacks usage guidance keywords (${GUIDANCE_HINTS.join("/")})`).toBe(true);
+    }
+  });
+});
+
+describe("TDQS — Behavioral Transparency", () => {
+  it("every tool declares annotations", () => {
+    for (const t of tools) {
+      expect(t.annotations, `${t.name}: missing annotations object`).toBeDefined();
+    }
+  });
+
+  it("every tool declares all four behavioral hints (readOnly/destructive/idempotent/openWorld)", () => {
+    for (const t of tools) {
+      const a = t.annotations!;
+      expect(typeof a.readOnlyHint, `${t.name}: missing readOnlyHint`).toBe("boolean");
+      expect(typeof a.destructiveHint, `${t.name}: missing destructiveHint`).toBe("boolean");
+      expect(typeof a.idempotentHint, `${t.name}: missing idempotentHint`).toBe("boolean");
+      expect(typeof a.openWorldHint, `${t.name}: missing openWorldHint`).toBe("boolean");
+    }
+  });
+
+  it("read-only tools are not also marked destructive", () => {
+    for (const t of tools) {
+      const a = t.annotations!;
+      if (a.readOnlyHint === true) {
+        expect(a.destructiveHint, `${t.name}: readOnly + destructive is contradictory`).toBe(false);
+      }
+    }
+  });
+});
+
+describe("TDQS — Parameter Semantics", () => {
+  it("every input parameter has its own description", () => {
+    for (const t of tools) {
+      const props = t.inputSchema?.properties ?? {};
+      for (const [param, schema] of Object.entries(props)) {
+        expect(schema.description, `${t.name}.${param}: missing parameter description`).toBeTruthy();
+        expect(schema.description!.length, `${t.name}.${param}: description too short`).toBeGreaterThanOrEqual(10);
+      }
+    }
+  });
+});
+
+describe("TDQS — Conciseness & Structure", () => {
+  it("descriptions stay under 4 KB (room for guidance, not novellas)", () => {
+    for (const t of tools) {
+      expect(t.description!.length, `${t.name}: description too long`).toBeLessThan(4_000);
+    }
+  });
+});
+
+describe("TDQS — Server Coherence", () => {
+  it("tool names are unique", () => {
+    const names = tools.map(t => t.name);
+    expect(new Set(names).size).toBe(names.length);
+  });
+
+  it("tool names use snake_case (no camelCase, no spaces)", () => {
+    for (const t of tools) {
+      expect(t.name, `${t.name}: must match ^[a-z][a-z0-9_]*$`).toMatch(/^[a-z][a-z0-9_]*$/);
+    }
+  });
+
+  it("memory_* tools all share the memory_ prefix (naming consistency)", () => {
+    const memoryTools = tools.filter(t => t.name.startsWith("memory_"));
+    expect(memoryTools.length).toBeGreaterThan(10);
   });
 });

--- a/tests/tools/tool-descriptions.test.ts
+++ b/tests/tools/tool-descriptions.test.ts
@@ -14,7 +14,6 @@
 // response) so they protect every future tool addition automatically.
 
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
-import { spawnSync } from "node:child_process";
 import { existsSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
@@ -27,6 +26,11 @@ type Tool = {
   title?: string;
   description?: string;
   inputSchema?: {
+    type?: string;
+    properties?: Record<string, { description?: string; type?: string | string[] }>;
+    required?: string[];
+  };
+  outputSchema?: {
     type?: string;
     properties?: Record<string, { description?: string; type?: string | string[] }>;
     required?: string[];
@@ -47,24 +51,10 @@ let dbPath = "";
 let tools: Tool[] = [];
 
 beforeAll(async () => {
-  const buildResult = spawnSync(
-    "./node_modules/.bin/tsup",
-    [
-      "src/index.ts",
-      "src/cli/main.ts",
-      "src/hooks/search-context.ts",
-      "src/hooks/session-context.ts",
-      "src/hooks/auto-capture-bin.ts",
-      "src/hooks/session-summarize-bin.ts",
-      "--format", "esm", "--dts", "--clean",
-    ],
-    { cwd: process.cwd(), encoding: "utf-8", timeout: 120_000 },
-  );
-  if (buildResult.status !== 0) {
-    throw new Error(`Build prerequisite failed.\nstderr: ${buildResult.stderr}\nstdout: ${buildResult.stdout}`);
-  }
+  // The MCP server binary is built once by tests/setup/build-once.ts
+  // (registered as vitest globalSetup), so we just check the artifact exists.
   if (!existsSync(distEntry)) {
-    throw new Error(`Built MCP server missing at ${distEntry}`);
+    throw new Error(`Built MCP server missing at ${distEntry} (expected globalSetup to produce it).`);
   }
 
   const fakeHome = join(tmpdir(), `mcp-tdqs-home-${process.pid}-${randomUUID()}`);
@@ -159,9 +149,29 @@ describe("TDQS — Parameter Semantics", () => {
 });
 
 describe("TDQS — Conciseness & Structure", () => {
-  it("descriptions stay under 4 KB (room for guidance, not novellas)", () => {
+  it("descriptions stay under 1.5 KB (room for guidance, not novellas)", () => {
     for (const t of tools) {
-      expect(t.description!.length, `${t.name}: description too long`).toBeLessThan(4_000);
+      expect(t.description!.length, `${t.name}: description too long (${t.description!.length} chars)`).toBeLessThan(1_500);
+    }
+  });
+});
+
+describe("TDQS — Contextual Completeness", () => {
+  it("every tool declares an outputSchema", () => {
+    for (const t of tools) {
+      expect(t.outputSchema, `${t.name}: missing outputSchema`).toBeDefined();
+      expect(t.outputSchema!.properties, `${t.name}: outputSchema has no properties`).toBeDefined();
+      expect(Object.keys(t.outputSchema!.properties!).length, `${t.name}: outputSchema is empty`).toBeGreaterThan(0);
+    }
+  });
+
+  it("every outputSchema property carries a description", () => {
+    for (const t of tools) {
+      const props = t.outputSchema?.properties ?? {};
+      for (const [field, schema] of Object.entries(props)) {
+        expect(schema.description, `${t.name}.outputSchema.${field}: missing description`).toBeTruthy();
+        expect(schema.description!.length, `${t.name}.outputSchema.${field}: description too short`).toBeGreaterThanOrEqual(10);
+      }
     }
   });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -21,6 +21,10 @@ export default defineConfig({
     globals: true,
     include: ["tests/**/*.test.ts"],
     testTimeout: 10000,
+    // Built once before any spec runs; integration specs that spawn the MCP
+    // server consume `dist/index.js` directly and would otherwise race each
+    // other when each tried to rebuild + clean the same directory.
+    globalSetup: ["tests/setup/build-once.ts"],
     coverage: {
       provider: "v8",
       reporter: ["text", "json-summary"],


### PR DESCRIPTION
## Summary

This PR upgrades the memento-mcp server's tool definitions to meet the Tool Definition Quality Score (TDQS) v2 standard. The changes introduce comprehensive tool metadata (titles, detailed descriptions, behavioral annotations), structured output schemas for four key tools, and a new test suite to enforce quality standards across all tool definitions.

## Key Changes

- **Tool Registration API**: Migrated from `server.tool()` to `server.registerTool()` with the new MCP SDK shape, including `title`, `description`, `inputSchema`, `annotations`, and `outputSchema` fields.

- **Comprehensive Tool Metadata**:
  - Added human-friendly titles and substantive descriptions (60+ chars) for all 20+ tools
  - Descriptions now include usage guidance (when/why/prefer patterns) and cross-references to related tools
  - Every input parameter now has its own description with type hints and constraints

- **Behavioral Annotations**: All tools now declare four boolean hints:
  - `readOnlyHint` — whether the tool modifies state
  - `destructiveHint` — whether the tool deletes or overwrites data
  - `idempotentHint` — whether repeated calls are safe
  - `openWorldHint` — whether the tool makes external API calls

- **Structured Output Schemas**: Four tools now expose rich `outputSchema` definitions:
  - `memory_search` — returns `{ query, detail, count, results[], vault_results[], total_tokens }`
  - `memory_list` — returns `{ detail, count, memories[], vault_results[] }`
  - `memory_graph` — returns `{ found, root, edges[] }`
  - `memory_path` — returns `{ found, hops, path[] }`

- **Dual-Mode Tool Handlers**: Tools with structured outputs now return `{ text, structured }` pairs, ensuring both human-readable text and machine-parseable JSON are always in sync.

- **TDQS Test Suite** (`tests/tools/tool-descriptions.test.ts`):
  - Boots the actual MCP server and introspects its `listTools()` response
  - Validates all six TDQS dimensions: Purpose Clarity, Usage Guidelines, Behavioral Transparency, Parameter Semantics, Conciseness, and Contextual Completeness
  - Automatically protects all future tool additions

- **Structured Payload Unit Tests** (`tests/tools/structured-payloads.test.ts`):
  - Verifies that text and structured outputs describe the same result set
  - Ensures required fields are populated and shapes match declared schemas
  - Prevents drift between rendering layers

- **Build Infrastructure**:
  - Added `tests/setup/build-once.ts` as a Vitest `globalSetup` to build the MCP server once before any integration spec runs
  - Prevents race conditions when multiple specs spawn the server

- **Version Bump**: Updated server version from `1.0.0` to `2.1.6`

- **Glama Registry**: Added `glama.json` metadata file for MCP server registry integration

## Notable Implementation Details

- The `textResult()` helper wraps simple string responses into the MCP SDK's expected shape: `{ content: [{ type: "text", text }], structuredContent: { message } }`
- Tool descriptions use multi-line arrays joined with spaces to stay readable in source while meeting the 60+ char minimum
- Input schemas use Zod's `.describe()` method to attach per-parameter documentation
- Structured payloads are computed from the same in-memory result set as text rendering, guaranteeing consistency
- The TDQS test suite is schema-level (introspects MCP responses) rather than hardcoding tool names, so it automatically validates any future tools added to the server

https://claude.ai/code/session_01A8xKBBbBwnBErePuQq3Bk8