### PR TITLE
chore(release): v2.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@luispmonteiro/memento-memory-mcp",
-  "version": "2.1.8",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@luispmonteiro/memento-memory-mcp",
-      "version": "2.1.8",
+      "version": "2.2.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luispmonteiro/memento-memory-mcp",
-  "version": "2.1.8",
+  "version": "2.2.0",
   "description": "Persistent memory MCP server with typed memories, decay scoring, and token-aware context injection",
   "type": "module",
   "engines": {


### PR DESCRIPTION
Automated version bump for v2.2.0. Already published to npm and tagged.