### PR TITLE
Configure pnpm to only build better-sqlite3 dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,5 +49,10 @@
   ],
   "publishConfig": {
     "access": "public"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "better-sqlite3"
+    ]
   }
 }


### PR DESCRIPTION
## Summary
Added pnpm configuration to optimize dependency installation by specifying that only `better-sqlite3` should be built from source, while other dependencies use prebuilt binaries.

## Changes
- Added `pnpm.onlyBuiltDependencies` configuration in `package.json`
- Configured `better-sqlite3` as the only dependency that requires building from source

## Details
This configuration improves installation performance by allowing pnpm to use prebuilt binaries for most dependencies while ensuring `better-sqlite3` is properly built for the target environment. This is particularly useful in CI/CD pipelines and development environments where build times matter.

https://claude.ai/code/session_01JvWnu8cUyXKd4wegLLTine