### PR TITLE
deps: pin protobufjs ^7.5.5 (GHSA-xq3m-2v4x-88gg)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1132,13 +1132,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/long": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
-      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/@types/node": {
       "version": "22.19.17",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
@@ -3406,31 +3399,36 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "6.11.6",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.6.tgz",
-      "integrity": "sha512-k8BHqgPBOtrlougZZqF2uUk5Z7bN8f0wj+3e8M3hvtSv0NBAz4VBy5f6R5Nxq/l+i7mRFTgNZb2trxqTpHNY/A==",
+      "version": "7.5.6",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.6.tgz",
+      "integrity": "sha512-M71sTMB146U3u0di3yup8iM+zv8yPRNQVr1KK4tyBitl3qFvEGucq/rGDRShD2rsJhtN02RJaJ7j5X5hmy8SJg==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "optional": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/codegen": "^2.0.5",
         "@protobufjs/eventemitter": "^1.1.0",
         "@protobufjs/fetch": "^1.1.0",
         "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/inquire": "^1.1.1",
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/long": "^4.0.1",
+        "@protobufjs/utf8": "^1.1.1",
         "@types/node": ">=13.7.0",
-        "long": "^4.0.0"
+        "long": "^5.0.0"
       },
-      "bin": {
-        "pbjs": "bin/pbjs",
-        "pbts": "bin/pbts"
+      "engines": {
+        "node": ">=12.0.0"
       }
+    },
+    "node_modules/protobufjs/node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0",
+      "optional": true
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",

--- a/package.json
+++ b/package.json
@@ -53,9 +53,15 @@
   "optionalDependencies": {
     "@xenova/transformers": "^2.17.2"
   },
+  "overrides": {
+    "protobufjs": "^7.5.5"
+  },
   "pnpm": {
     "onlyBuiltDependencies": [
       "better-sqlite3"
-    ]
+    ],
+    "overrides": {
+      "protobufjs": "^7.5.5"
+    }
   }
 }


### PR DESCRIPTION
## Summary

Forces protobufjs to a patched version (≥ 7.5.5) via npm + pnpm `overrides`. Closes Dependabot alert #4 (CVE-2026-41242, CVSS 9.8).

The vulnerable 6.11.6 is pulled transitively: `@xenova/transformers → onnxruntime-web → onnx-proto → protobufjs`. The exploit requires loading an attacker-controlled `.proto` schema and reaching the generated-code path; we only load pre-compiled ONNX models from HuggingFace, so the practical threat surface was already zero. This is defense-in-depth that also clears the alert.

## Other Dependabot alerts

The remaining 3 medium-severity alerts on master have been dismissed as `tolerable_risk`:

- **#1 esbuild ≤ 0.24.2** — dev-server CORS leak. We never run a dev server (vitest test runner only). Production binaries built with tsup-bundled esbuild 0.27.7.
- **#2 vite ≤ 6.4.1** — path traversal in dev-server `.map` handling, only triggers with `--host`. Same situation as #1.
- **#3 astro < 6.1.6** — XSS in `define:vars` only fires under SSR with user-controlled input. `site/` is statically generated (no `output: 'server'` in `astro.config.mjs`). Astro 6 upgrade attempted but `@tailwindcss/vite@4` is not yet compatible with Astro 6's rolldown-vite — staying on 5.x until the ecosystem catches up.

## Test plan

- [x] `npm install` resolves `protobufjs@7.5.6` (verified locally via `npm ls protobufjs`)
- [x] Full suite passes: 1467/1467 vitest tests
- [x] `npm audit` no longer reports protobufjs (only the 6 dev-only vite/esbuild medium remain — covered by alerts dismissed above)